### PR TITLE
chore(wgebra): document the wgebra crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,29 @@
 
 -----
 
-**wgmath** is a set of [Rust](https://www.rust-lang.org/) libraries exposing re-usable GPU shaders for scientific
-computing including:
+**wgmath** is a set of [Rust](https://www.rust-lang.org/) libraries exposing
+re-usable [WebGPU](https://www.w3.org/TR/WGSL/) shaders for scientific computing including:
 
-- Linear algebra with the **wgebra** crate.
-- AI (Large Language Models) with the **wgml** crate.
-- Collision-detection with the **wgparry2d** and **wgparry3d** crates (still very WIP).
-- Rigid-body physics with the **wgrapier2d** and **wgrapier3d** crates( (still very WIP).
-- Non-rigid physics with the **.
-  By targeting WebGPU, these libraries run on most GPUs, including on mobile and on the web. It aims to promote open and
-  cross-platform GPU computing for scientific applications, a field currently strongly dominated by proprietary
-  solutions (like CUDA).
+- The [**wgcore** crate](https://github.com/dimforge/wgmath/tree/main/crates/wgcore), a centerpiece of the **wgmath**
+  ecosystem, exposes a set of proc-macros to facilitate sharing and composing shaders across Rust libraries.
+- Linear algebra with the [**wgebra** crate](https://github.com/dimforge/wgmath/tree/main/crates/wgebra).
+- AI (Large Language Models) with the [**wgml** crate](https://github.com/dimforge/wgml/tree/main).
+- Collision-detection with the
+  [**wgparry2d** and **wgparry3d**](https://github.com/dimforge/wgmath/tree/main/crates/wgparry) crates (still very
+  WIP).
+- Rigid-body physics with the
+  [**wgrapier2d** and **wgrapier3d**](https://github.com/dimforge/wgmath/tree/main/crates/wgrapier3d) crates (still very
+  WIP).
 
-All of the libraries are still under heavy development and might be lacking some important features. Contributions are
-welcome!
+By targeting WebGPU, these libraries run on most GPUs, including on mobile and on the web. It aims to promote open and
+cross-platform GPU computing for scientific applications, a field currently strongly dominated by proprietary
+solutions (like CUDA).
 
-In particular, the **wgcore** crate part of the **wgmath** ecosystem exposes a set of proc-macros to facilitate sharing
-and composing shaders across Rust libraries.
+⚠️ All these libraries are still under heavy development and might be lacking some important features. Contributions
+are welcome!
 
-See the readme of each individual crate (on the `crates` directory) for additional details.
+----
+
+**See the readme of each individual crate (on the `crates` directory) for additional details.**
+
+----

--- a/crates/wgebra/README.md
+++ b/crates/wgebra/README.md
@@ -1,7 +1,59 @@
 # wgebra − composable WGSL shaders for linear algebra
 
-**/!\ This library is still under heavy development and is still missing many features.**
+<p align="center">
+  <img src="https://wgmath.rs/img/logo_wgebra.svg" alt="crates.io" height="200px">
+</p>
 
-The goal of **wgebra** is to especially be "**nalgebra** on the gpu". It aims (but it isn’t there yet) to expose linear
-algebra operations (including BLAS-like and LAPACK-like operations) as well as geometric types (quaternions,
-similarities, etc.) as composable WGSl shaders and kernels.
+----
+
+The goal of **wgebra** is to especially be "[**nalgebra**](https://nalgebra.rs) on the gpu". It aims (but it isn’t there
+yet) to expose linear algebra operations (including BLAS-like and LAPACK-like operations) as well as geometric types
+(quaternions, similarities, etc.) as composable WGSL shaders and kernels.
+
+## Reusable shader functions
+
+**wgebra** exposes various reusable WGSL shaders to be composed with your owns. This exposes various functionalities
+that are not covered by the mathematical functions included in the WebGPU standard:
+
+- Low-dimensional matrix decompositions:
+    - Inverse, Cholesky, LU, QR, Symmetric Eigendecomposition, for 2x2, 3x3, and 4x4 matrices.
+    - Singular Values Decomposition for 2x2 and 3x3 matrices.
+- Geometric transformations:
+    - Quaternions (for 3D rotations).
+    - Compact 2D rotation representation.
+    - 2D and 3D similarities (rotations + translation + uniform scale).
+
+## Kernels
+
+**wgebra** exposes kernels for running common linear-algebra operations on vectors, matrices, and 3-tensors. In
+particular:
+
+- The product of two matrices: `Gemm` (including both `m1 * m2` and `transpose(m1) * m2`). Supports 3-tensors.
+- The product of a matrix and a vector: `Gemv` (including both `m * v` and `transpose(m) * v`). Supports 3-tensors.
+- Componentwise binary operations between two vectors (addition, subtraction, product, division, assignation).
+- Reduction on a single vector (sum, product, min, max, squared norm).
+
+## Using the library
+
+To access the features of **wgebra** on your own Rust project, add the dependency to your `Cargo.toml`:
+
+```toml
+[dependencies]
+wgebra = "0.2.0" # NOTE: set the version number to the latest.
+```
+
+Then shaders can be composed with your code, and kernels can be dispatched. For additional information, refer to
+the [user-guide](https://wgmath.rs/docs/).
+
+## Running tests
+
+Tests can be run the same way as usual:
+
+```sh
+cargo test
+```
+
+## Benchmarks
+
+There is currently no benchmark in the `wgebra` repository itself. However, some benchmarks of the matrix multiplication
+kernels can be run from [wgml-bench](https://github.com/dimforge/wgml/tree/main/crates/wgml-bench).

--- a/crates/wgebra/src/geometry/cholesky.wgsl
+++ b/crates/wgebra/src/geometry/cholesky.wgsl
@@ -4,6 +4,13 @@
 //       - DIM: the matrix dimension (e.g. `2` for 2x2 matrices).
 //       - MAT: the matrix type (e.g. `mat2x2<f32>` for a 2x2 matrix).
 //       - IMPORT_PATH: the `define_import_path` path.
+
+/// Computes the Cholesky decomposition of the given matrix.
+///
+/// The decomposition’s result is stored in the lower-triangular part of the output matrix.
+///
+/// For additional information on the Cholesky decomposition, see the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack/#cholesky-decomposition)
+/// documentation.
 fn cholesky(x: MAT) -> MAT {
     var m = x;
 

--- a/crates/wgebra/src/geometry/eig2.rs
+++ b/crates/wgebra/src/geometry/eig2.rs
@@ -10,16 +10,19 @@ use {
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 /// GPU representation of a symmetric 2x2 matrix eigendecomposition.
+///
+/// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack/#eigendecomposition-of-a-hermitian-matrix)
+/// documentation for details on the eigendecomposition
 pub struct GpuSymmetricEigen2 {
     /// Eigenvectors of the matrix.
     pub eigenvectors: Matrix2<f32>,
-    /// Singular values.
+    /// Eigenvalues of the matrix.
     pub eigenvalues: Vector2<f32>,
 }
 
 #[derive(Shader)]
 #[shader(src = "eig2.wgsl")]
-/// Shader for computing the Singular Value Decomposition of 2x2 matrices.
+/// Shader for computing the eigendecomposition of symmetric 2x2 matrices.
 pub struct WgSymmetricEigen2;
 
 impl WgSymmetricEigen2 {

--- a/crates/wgebra/src/geometry/eig2.rs
+++ b/crates/wgebra/src/geometry/eig2.rs
@@ -26,6 +26,7 @@ pub struct GpuSymmetricEigen2 {
 pub struct WgSymmetricEigen2;
 
 impl WgSymmetricEigen2 {
+    #[doc(hidden)]
     #[cfg(test)]
     pub fn tests(device: &Device) -> ComputePipeline {
         let test_kernel = r#"

--- a/crates/wgebra/src/geometry/eig2.wgsl
+++ b/crates/wgebra/src/geometry/eig2.wgsl
@@ -1,12 +1,17 @@
 #define_import_path wgebra::eig2
 
-// The SVD of a 2x2 matrix.
+// The eigendecomposition of a symmetric 2x2 matrix.
+///
+/// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack/#eigendecomposition-of-a-hermitian-matrix)
+/// documentation for details on the eigendecomposition.
 struct SymmetricEigen {
+    /// Eigenvectors of the matrix.
     eigenvectors: mat2x2<f32>,
+    /// Eigenvalues of the matrix.
     eigenvalues: vec2<f32>,
 };
 
-// Computes the SVD of a 2x2 matrix.
+// Computes the eigendecomposition of a symmetric 2x2 matrix.
 fn symmetric_eigen(m: mat2x2<f32>) -> SymmetricEigen {
     let a = m.x.x;
     let c = m.x.y;

--- a/crates/wgebra/src/geometry/eig3.rs
+++ b/crates/wgebra/src/geometry/eig3.rs
@@ -29,6 +29,7 @@ pub struct WgSymmetricEigen3;
 test_shader_compilation!(WgSymmetricEigen3);
 
 impl WgSymmetricEigen3 {
+    #[doc(hidden)]
     #[cfg(test)]
     pub fn tests(device: &Device) -> ComputePipeline {
         let test_kernel = r#"

--- a/crates/wgebra/src/geometry/eig3.rs
+++ b/crates/wgebra/src/geometry/eig3.rs
@@ -11,16 +11,19 @@ use {
 #[derive(Copy, Clone, Debug, encase::ShaderType)]
 #[repr(C)]
 /// GPU representation of a symmetric 3x3 matrix eigendecomposition.
+///
+/// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack/#eigendecomposition-of-a-hermitian-matrix)
+/// documentation for details on the eigendecomposition
 pub struct GpuSymmetricEigen3 {
     /// Eigenvectors of the matrix.
     pub eigenvectors: Matrix3<f32>,
-    /// Singular values.
+    /// Eigenvalues of the matrix.
     pub eigenvalues: Vector3<f32>,
 }
 
 #[derive(Shader)]
 #[shader(derive(WgMinMax, WgSymmetricEigen2, WgRot2), src = "eig3.wgsl")]
-/// Shader for computing the Singular Value Decomposition of 3x3 matrices.
+/// Shader for computing the eigendecomposition of symmetric 3x3 matrices.
 pub struct WgSymmetricEigen3;
 
 test_shader_compilation!(WgSymmetricEigen3);

--- a/crates/wgebra/src/geometry/eig3.wgsl
+++ b/crates/wgebra/src/geometry/eig3.wgsl
@@ -4,9 +4,14 @@
 #import wgebra::eig2 as Eig2
 #import wgebra::min_max as MinMax
 
-// The SVD of a 3x3 matrix.
+// The eigendecomposition of a symmetric 3x3 matrix.
+///
+/// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack/#eigendecomposition-of-a-hermitian-matrix)
+/// documentation for details on the eigendecomposition.
 struct SymmetricEigen {
+    /// Eigenvectors of the matrix.
     eigenvectors: mat3x3<f32>,
+    /// Eigenvalues of the matrix.
     eigenvalues: vec3<f32>,
 }
 
@@ -15,7 +20,7 @@ struct Tridiag {
     off_diag: vec2<f32>
 }
 
-// Computes the SVD of a 3x3 matrix.
+// Computes the eigendecomposition of a symmetric 4x4 matrix.
 fn symmetric_eigen(x: mat3x3<f32>) -> SymmetricEigen {
     const DIM: u32 = 3;
     const EPS: f32 = 1.1920929e-7;

--- a/crates/wgebra/src/geometry/eig4.rs
+++ b/crates/wgebra/src/geometry/eig4.rs
@@ -11,16 +11,19 @@ use {
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 /// GPU representation of a symmetric 4x4 matrix eigendecomposition.
+///
+/// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack/#eigendecomposition-of-a-hermitian-matrix)
+/// documentation for details on the eigendecomposition
 pub struct GpuSymmetricEigen4 {
     /// Eigenvectors of the matrix.
     pub eigenvectors: Matrix4<f32>,
-    /// Singular values.
+    /// Eigenvalues of the matrix.
     pub eigenvalues: Vector4<f32>,
 }
 
 #[derive(Shader)]
 #[shader(derive(WgMinMax, WgSymmetricEigen2, WgRot2), src = "eig4.wgsl")]
-/// Shader for computing the Singular Value Decomposition of 4x4 matrices.
+/// Shader for computing the eigendecomposition of symmetric 4x4 matrices.
 pub struct WgSymmetricEigen4;
 
 test_shader_compilation!(WgSymmetricEigen4);

--- a/crates/wgebra/src/geometry/eig4.rs
+++ b/crates/wgebra/src/geometry/eig4.rs
@@ -29,6 +29,7 @@ pub struct WgSymmetricEigen4;
 test_shader_compilation!(WgSymmetricEigen4);
 
 impl WgSymmetricEigen4 {
+    #[doc(hidden)]
     #[cfg(test)]
     pub fn tests(device: &Device) -> ComputePipeline {
         let test_kernel = r#"

--- a/crates/wgebra/src/geometry/eig4.wgsl
+++ b/crates/wgebra/src/geometry/eig4.wgsl
@@ -4,9 +4,14 @@
 #import wgebra::eig2 as Eig2
 #import wgebra::min_max as MinMax
 
-// The SVD of a 4x4 matrix.
+// The eigendecomposition of a symmetric 4x4 matrix.
+///
+/// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack/#eigendecomposition-of-a-hermitian-matrix)
+/// documentation for details on the eigendecomposition.
 struct SymmetricEigen {
+    /// Eigenvectors of the matrix.
     eigenvectors: mat4x4<f32>,
+    /// Eigenvalues of the matrix.
     eigenvalues: vec4<f32>,
 }
 
@@ -15,7 +20,7 @@ struct Tridiag {
     off_diag: vec3<f32>
 }
 
-// Computes the SVD of a 4x4 matrix.
+// Computes the eigendecomposition of a symmetric 4x4 matrix.
 fn symmetric_eigen(x: mat4x4<f32>) -> SymmetricEigen {
     const DIM: u32 = 4;
     const EPS: f32 = 1.1920929e-7;

--- a/crates/wgebra/src/geometry/lu.rs
+++ b/crates/wgebra/src/geometry/lu.rs
@@ -28,18 +28,31 @@ fn substitute4(src: &str) -> String {
 
 macro_rules! gpu_output_types(
     ($GpuPermutation: ident, $GpuLU: ident, $R: literal, $C: literal, $Perm: literal) => {
+        /// Structure describing a permutation sequence applied by the LU decomposition.
         #[derive(ShaderType, Copy, Clone, PartialEq)]
         #[repr(C)]
         pub struct $GpuPermutation {
+            /// First permutation indices (row `ia[i]` is permuted with row`ib[i]`].
             pub ia: SVector<u32, $Perm>,
+            /// Second permutation indices (row `ia[i]` is permuted with row`ib[i]`].
             pub ib: SVector<u32, $Perm>,
+            /// The number of permutations in `self`. Only the first `len` elements of
+            /// [`Self::ia`] and [`Self::ib`] need to be taken into account.
             pub len: u32,
         }
 
+        /// GPU representation of a matrix LU decomposition (with partial pivoting).
+        ///
+        /// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack#lu-with-partial-or-full-pivoting) documentation
+        /// for details on the LU decomposition.
         #[derive(ShaderType, Copy, Clone, PartialEq)]
         #[repr(C)]
         pub struct $GpuLU {
+            /// The LU decomposition where both lower and upper-triangular matrices are stored
+            /// in the same matrix. In particular the diagonal full of `1` of the lower-triangular
+            /// matrix isn’t stored explicitly.
             pub lu: SMatrix<f32, $R, $C>,
+            /// The row permutations applied during the decomposition.
             pub p: $GpuPermutation,
         }
     }
@@ -52,17 +65,17 @@ gpu_output_types!(GpuPermutations4, GpuLU4, 4, 4, 4);
 // TODO: rectangular matrices
 #[derive(Shader)]
 #[shader(src = "lu.wgsl", src_fn = "substitute2")]
-/// Shader for computing the Cholesky decomposition of a symmetric-definite-positive 2x2 matrix.
+/// Shader for computing the LU decomposition of a 2x2 matrix.
 pub struct WgLU2;
 
 #[derive(Shader)]
 #[shader(src = "lu.wgsl", src_fn = "substitute3")]
-/// Shader for computing the Cholesky decomposition of a symmetric-definite-positive 2x2 matrix.
+/// Shader for computing the LU decomposition of a 3x3 matrix.
 pub struct WgLU3;
 
 #[derive(Shader)]
 #[shader(src = "lu.wgsl", src_fn = "substitute4")]
-/// Shader for computing the Cholesky decomposition of a symmetric-definite-positive 2x2 matrix.
+/// Shader for computing the LU decomposition of a 4x4 matrix.
 pub struct WgLU4;
 
 test_shader_compilation!(WgLU2);

--- a/crates/wgebra/src/geometry/lu.wgsl
+++ b/crates/wgebra/src/geometry/lu.wgsl
@@ -8,23 +8,31 @@
 //       - MAT: the matrix type (e.g. `mat2x2<f32>` for a 2x2 matrix).
 //       - IMPORT_PATH: the `define_import_path` path.
 
+/// Structure describing a permutation sequence applied by the LU decomposition.
 struct Permutations {
-    /// First permutation index.
+    /// First permutation indices (row `ia[i]` is permuted with row`ib[i]`].
     ia: PERM,
-    /// Second permutation index.
+    /// Second permutation indices (row `ia[i]` is permuted with row`ib[i]`].
     ib: PERM,
-    /// The number of cative permutations.
+    /// The number of permutations in `self`. Only the first `len` elements of
+    /// [`Self::ia`] and [`Self::ib`] need to be taken into account.
     len: u32
 }
 
+/// GPU representation of a matrix LU decomposition (with partial pivoting).
+///
+/// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack#lu-with-partial-or-full-pivoting) documentation
+/// for details on the LU decomposition.
 struct LU {
-    /// The LU decomposition.
+    /// The LU decomposition where both lower and upper-triangular matrices are stored
+    /// in the same matrix. In particular the diagonal full of `1` of the lower-triangular
+    /// matrix isn’t stored explicitly.
     lu: MAT,
-    /// The row permutations applied during pivoting.
+    /// The row permutations applied during the decomposition.
     p: Permutations
 }
 
-
+/// Computse the LU decomposition of the matrix.
 fn lu(x: MAT) -> LU {
     let min_nrows_ncols = min(NROWS, NCOLS);
     var p = Permutations();

--- a/crates/wgebra/src/geometry/qr2.rs
+++ b/crates/wgebra/src/geometry/qr2.rs
@@ -8,9 +8,14 @@ use {
 
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
-/// GPU representation of a 4x4 matrix QR decomposition.
+/// GPU representation of a 2x2 matrix QR decomposition.
+///
+/// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack#qr)
+/// documentation for details on the QR decomposition.
 pub struct GpuQR2 {
+    /// The QR decomposition’s 2x2 unitary matrix.
     pub q: Matrix2<f32>,
+    /// The QR decomposition’s 2x2 upper-triangular matrix.
     pub r: Matrix2<f32>,
 }
 

--- a/crates/wgebra/src/geometry/qr2.rs
+++ b/crates/wgebra/src/geometry/qr2.rs
@@ -27,6 +27,7 @@ pub struct WgQR2;
 test_shader_compilation!(WgQR2);
 
 impl WgQR2 {
+    #[doc(hidden)]
     #[cfg(test)]
     pub fn tests(device: &Device) -> ComputePipeline {
         let test_kernel = r#"

--- a/crates/wgebra/src/geometry/qr2.wgsl
+++ b/crates/wgebra/src/geometry/qr2.wgsl
@@ -1,8 +1,13 @@
 #define_import_path wgebra::qr2
 
-// The QR decomposition of a 2x2 matrix.
+/// The QR decomposition of a 2x2 matrix.
+///
+/// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack#qr)
+/// documentation for details on the QR decomposition.
 struct QR {
+    /// The QR decomposition’s 2x2 unitary matrix.
     q: mat2x2<f32>,
+    /// The QR decomposition’s 2x2 upper-triangular matrix.
     r: mat2x2<f32>
 }
 

--- a/crates/wgebra/src/geometry/qr3.rs
+++ b/crates/wgebra/src/geometry/qr3.rs
@@ -27,6 +27,7 @@ pub struct WgQR3;
 test_shader_compilation!(WgQR3);
 
 impl WgQR3 {
+    #[doc(hidden)]
     #[cfg(test)]
     pub fn tests(device: &Device) -> ComputePipeline {
         let test_kernel = r#"

--- a/crates/wgebra/src/geometry/qr3.rs
+++ b/crates/wgebra/src/geometry/qr3.rs
@@ -9,8 +9,13 @@ use {
 #[derive(Copy, Clone, Debug, encase::ShaderType)]
 #[repr(C)]
 /// GPU representation of a 3x3 matrix QR decomposition.
+///
+/// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack#qr)
+/// documentation for details on the QR decomposition.
 pub struct GpuQR3 {
+    /// The QR decomposition’s 3x3 unitary matrix.
     pub q: Matrix3<f32>,
+    /// The QR decomposition’s 3x3 upper-triangular matrix.
     pub r: Matrix3<f32>,
 }
 

--- a/crates/wgebra/src/geometry/qr3.wgsl
+++ b/crates/wgebra/src/geometry/qr3.wgsl
@@ -1,12 +1,17 @@
 #define_import_path wgebra::qr3
 
-// The QR decomposition of a 3x3 matrix.
+/// The QR decomposition of a 3x3 matrix.
+///
+/// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack#qr)
+/// documentation for details on the QR decomposition.
 struct QR {
+    /// The QR decomposition’s 3x3 unitary matrix.
     q: mat3x3<f32>,
+    /// The QR decomposition’s 3x3 upper-triangular matrix.
     r: mat3x3<f32>
 }
 
-// Computes the QR decomposition of a 3x3 matrix.
+/// Computes the QR decomposition of a 3x3 matrix.
 fn qr(x: mat3x3<f32>) -> QR {
     const DIM = 3;
     var m = x;

--- a/crates/wgebra/src/geometry/qr4.rs
+++ b/crates/wgebra/src/geometry/qr4.rs
@@ -9,8 +9,13 @@ use {
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 /// GPU representation of a 4x4 matrix QR decomposition.
+///
+/// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack#qr) documentation
+/// for details on the QR decomposition.
 pub struct GpuQR4 {
+    /// The QR decomposition’s 4x4 unitary matrix.
     pub q: Matrix4<f32>,
+    /// The QR decomposition’s 4x4 upper-triangular matrix.
     pub r: Matrix4<f32>,
 }
 

--- a/crates/wgebra/src/geometry/qr4.rs
+++ b/crates/wgebra/src/geometry/qr4.rs
@@ -27,6 +27,7 @@ pub struct WgQR4;
 test_shader_compilation!(WgQR4);
 
 impl WgQR4 {
+    #[doc(hidden)]
     #[cfg(test)]
     pub fn tests(device: &Device) -> ComputePipeline {
         let test_kernel = r#"

--- a/crates/wgebra/src/geometry/qr4.wgsl
+++ b/crates/wgebra/src/geometry/qr4.wgsl
@@ -1,12 +1,17 @@
 #define_import_path wgebra::qr4
 
-// The QR decomposition of a 4x4 matrix.
+/// The QR decomposition of a 4x4 matrix.
+///
+/// See the [nalgebra](https://nalgebra.rs/docs/user_guide/decompositions_and_lapack#qr) documentation
+/// for details on the QR decomposition.
 struct QR {
+    /// The QR decomposition’s 4x4 unitary matrix.
     q: mat4x4<f32>,
+    /// The QR decomposition’s 4x4 upper-triangular matrix.
     r: mat4x4<f32>
 }
 
-// Computes the QR decomposition of a 4x4 matrix.
+/// Computes the QR decomposition of a 4x4 matrix.
 fn qr(x: mat4x4<f32>) -> QR {
     const DIM = 4;
     var m = x;

--- a/crates/wgebra/src/geometry/sim2.rs
+++ b/crates/wgebra/src/geometry/sim2.rs
@@ -47,6 +47,7 @@ impl From<Isometry2<f32>> for GpuSim2 {
 pub struct WgSim2;
 
 impl WgSim2 {
+    #[doc(hidden)]
     #[cfg(test)]
     pub fn tests(device: &wgpu::Device) -> wgpu::ComputePipeline {
         let test_kernel = r#"

--- a/crates/wgebra/src/geometry/sim3.rs
+++ b/crates/wgebra/src/geometry/sim3.rs
@@ -11,6 +11,7 @@ pub type GpuSim3 = Similarity3<f32>;
 pub struct WgSim3;
 
 impl WgSim3 {
+    #[doc(hidden)]
     #[cfg(test)]
     pub fn tests(device: &wgpu::Device) -> wgpu::ComputePipeline {
         let test_kernel = r#"

--- a/crates/wgebra/src/geometry/svd2.rs
+++ b/crates/wgebra/src/geometry/svd2.rs
@@ -26,6 +26,7 @@ pub struct WgSvd2;
 
 impl WgSvd2 {
     #[cfg(test)]
+    #[doc(hidden)]
     pub fn tests(device: &Device) -> ComputePipeline {
         let test_kernel = r#"
  @group(0) @binding(0)

--- a/crates/wgebra/src/geometry/svd3.rs
+++ b/crates/wgebra/src/geometry/svd3.rs
@@ -28,6 +28,7 @@ pub struct WgSvd3;
 
 impl WgSvd3 {
     #[cfg(test)]
+    #[doc(hidden)]
     pub fn tests(device: &Device) -> ComputePipeline {
         let test_kernel = r#"
 @group(0) @binding(0)

--- a/crates/wgebra/src/lib.rs
+++ b/crates/wgebra/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![allow(clippy::too_many_arguments)]
-// #![warn(missing_docs)]
+#![warn(missing_docs)]
 
 pub use geometry::*;
 pub use linalg::*;

--- a/crates/wgebra/src/linalg/gemv.rs
+++ b/crates/wgebra/src/linalg/gemv.rs
@@ -12,16 +12,24 @@ use wgpu::{ComputePass, ComputePipeline, Device};
 pub struct Gemv {
     /// The compute pipeline for `matrix * vector`.
     pub gemv: ComputePipeline,
+    /// A compute pipeline for `matrix * vector` leveraging workgroup reduction.
     pub gemv_fast: ComputePipeline,
+    /// The compute pipeline for `transpose(matrix) * vector`.
     pub gemv_tr: ComputePipeline,
+    /// A compute pipeline for `transpose(matrix) * vector` leveraging workgroup reduction.
     pub gemv_tr_fast: ComputePipeline,
 }
 
+/// Variants used to select the specific kernel to dispatch from the [`Gemv`] shader.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum GemvVariant {
+    /// Multiplication of a vector by a matrix.
     Gemv,
+    /// An optimized version for multiplication of a vector by a matrix.
     GemvFast,
+    /// Multiplication of a vector by a transposed matrix.
     GemvTr,
+    /// An optimized version for multiplication of a vector by a transposed matrix.
     GemvTrFast,
 }
 
@@ -52,6 +60,7 @@ impl Gemv {
         self.dispatch_generic(device, shapes, pass, out, m, v, GemvVariant::GemvTr)
     }
 
+    /// Dispatches the matrix-vector multiplication variant indicated by the given [`GemvVariant`].
     pub fn dispatch_generic<'a, 'b, T: Pod>(
         &'a self,
         device: &Device,

--- a/crates/wgebra/src/linalg/shape.rs
+++ b/crates/wgebra/src/linalg/shape.rs
@@ -8,6 +8,8 @@ use wgcore::Shader;
 /// [`wgcore::shapes::ViewShape`].
 pub struct Shape;
 
+/// Shader definitions setting the `ROW_MAJOR` boolean macro for shaders supporting conditional
+/// compilation for switching row-major and column-major matrix handling.
 pub fn row_major_shader_defs() -> HashMap<String, ShaderDefValue> {
     [("ROW_MAJOR".to_string(), ShaderDefValue::Bool(true))].into()
 }

--- a/crates/wgebra/src/utils/min_max.rs
+++ b/crates/wgebra/src/utils/min_max.rs
@@ -1,5 +1,6 @@
 use wgcore::Shader;
 
+/// Helper shader functions for calculating the min/max elements of a vector or matrix.
 #[derive(Shader)]
 #[shader(src = "min_max.wgsl")]
 pub struct WgMinMax;

--- a/crates/wgebra/src/utils/min_max.wgsl
+++ b/crates/wgebra/src/utils/min_max.wgsl
@@ -1,42 +1,51 @@
 #define_import_path wgebra::min_max
 
+/// Computes the maximum value accross all elements of the given 2D vector.
 fn max2(v: vec2<f32>) -> f32 {
     return max(v.x, v.y);
 }
 
+/// Computes the maximum **absolute** value accross all elements of the given 2x2 matrix.
 fn amax2x2(m: mat2x2<f32>) -> f32 {
     let vm = max(abs(m.x), abs(m.y));
     return max(vm.x, vm.y);
 }
 
+/// Computes the maximum value accross all elements of the given 2x2 matrix.
 fn max2x2(m: mat2x2<f32>) -> f32 {
     let vm = max(m.x, m.y);
     return max(vm.x, vm.y);
 }
 
+/// Computes the maximum value accross all elements of the given 3D vector.
 fn max3(v: vec3<f32>) -> f32 {
     return max(v.x, max(v.y, v.z));
 }
 
+/// Computes the maximum **absolute** value accross all elements of the given 3x3 matrix.
 fn amax3x3(m: mat3x3<f32>) -> f32 {
     let vm = max(abs(m.x), max(abs(m.y), abs(m.z)));
     return max(vm.x, max(vm.y, vm.z));
 }
 
+/// Computes the maximum value accross all elements of the given 3x3 matrix.
 fn max3x3(m: mat3x3<f32>) -> f32 {
     let vm = max(m.x, max(m.y, m.z));
     return max(vm.x, max(vm.y, vm.z));
 }
 
+/// Computes the maximum value accross all elements of the given 4D vector.
 fn max4(v: vec4<f32>) -> f32 {
     return max(v.x, max(v.y, max(v.z, v.w)));
 }
 
+/// Computes the maximum **absolute** value accross all elements of the given 4x4 matrix.
 fn amax4x4(m: mat4x4<f32>) -> f32 {
     let vm = max(abs(m.x), max(abs(m.y), max(abs(m.z), abs(m.w))));
     return max(vm.x, max(vm.y, max(vm.z, vm.w)));
 }
 
+/// Computes the maximum value accross all elements of the given 4x4 matrix.
 fn max4x4(m: mat4x4<f32>) -> f32 {
     let vm = max(m.x, max(m.y, max(m.z, m.w)));
     return max(vm.x, max(vm.y, max(vm.z, vm.w)));

--- a/crates/wgebra/src/utils/trig.rs
+++ b/crates/wgebra/src/utils/trig.rs
@@ -1,5 +1,11 @@
 use wgcore::Shader;
 
+/// Alternative implementations of some geometric functions on the gpu.
+///
+/// Some platforms (Metal in particular) has implementations of some trigonometric functions
+/// that are not numerically stable. This is the case for example for `atan2` and `atanh` that
+/// may occasionally lead to NaNs. This shader exposes alternative implementations for numerically
+/// stable versions of these functions to ensure good behavior across all platforms.
 #[derive(Shader)]
 #[shader(src = "trig.wgsl")]
 pub struct WgTrig;


### PR DESCRIPTION
This enables documentation warnings on the `wgebra` crates, and fixes all the missing docs. This also adds documentation to the reusable WGSL shader functions, and update the main an `wgebra` README.