### PR TITLE
feat: implement broad-phase algorithms

### DIFF
--- a/crates/wgparry/src/bounding_volumes/aabb.rs
+++ b/crates/wgparry/src/bounding_volumes/aabb.rs
@@ -1,0 +1,33 @@
+//! Axis-Aligned Bounding Box (AABB) implementation.
+//!
+//! An AABB is the simplest and most widely used bounding volume, defined by its
+//! minimum and maximum corner points along each coordinate axis. AABBs are not
+//! rotated with the objects they bound; instead, they expand to accommodate rotation.
+//!
+//! # Properties
+//!
+//! - **Axis-aligned**: Edges are always parallel to coordinate axes.
+//! - **Conservative**: Always contains the entire object (may have empty space).
+//! - **Fast overlap test**: Just compare min/max coordinates (6 comparisons in 3D).
+//! - **Fast to compute**: For most shapes, AABB computation is very efficient.
+
+use crate::shapes::WgShape;
+use crate::substitute_aliases;
+use wgcore::{test_shader_compilation, Shader};
+use wgebra::{WgSim2, WgSim3};
+
+#[derive(Shader)]
+#[shader(
+    derive(WgSim3, WgSim2, WgShape),
+    src = "./aabb.wgsl",
+    src_fn = "substitute_aliases"
+)]
+/// GPU shader for computing and manipulating Axis-Aligned Bounding Boxes.
+///
+/// This shader provides functions for:
+/// - Computing AABBs from shapes.
+/// - AABB overlap testing.
+/// - AABB merging and manipulation.
+pub struct WgAabb;
+
+test_shader_compilation!(WgAabb);

--- a/crates/wgparry/src/bounding_volumes/aabb.wgsl
+++ b/crates/wgparry/src/bounding_volumes/aabb.wgsl
@@ -1,0 +1,103 @@
+//! Axis-Aligned Bounding Box (AABB) Module
+//!
+//! This module provides AABB computation and intersection testing for all shape types.
+//! AABBs are used extensively in broad-phase collision detection to quickly prune
+//! non-intersecting pairs.
+//!
+//! Key operations:
+//! - from_shape: Computes tight AABB for any shape type
+//! - check_intersection: Fast AABB-AABB overlap test
+//! - merge: Computes bounding AABB of two AABBs
+
+#define_import_path wgparry::bounding_volumes::aabb
+
+#if DIM == 2
+    #import wgebra::sim2 as Pose;
+    #import wgebra::rot2 as Rot;
+#else
+    #import wgebra::sim3 as Pose;
+    #import wgebra::quat as Rot;
+#endif
+
+#import wgparry::shape as Shape;
+
+/// An axis-aligned bounding box defined by minimum and maximum corners.
+struct Aabb {
+    /// Minimum corner (smallest coordinates along each axis).
+    mins: Vector,
+    /// Maximum corner (largest coordinates along each axis).
+    maxs: Vector
+}
+
+/// Creates an AABB from a transformed shape.
+fn from_shape(pose: Transform, shape: Shape::Shape) -> Aabb {
+    let ty = Shape::shape_type(shape);
+    if ty == Shape::SHAPE_TYPE_BALL {
+        let ball = Shape::to_ball(shape);
+#if DIM == 2
+        let tra = pose.translation;
+        let rad = ball.radius * pose.scale;
+#else
+        let tra = pose.translation_scale.xyz;
+        let rad = ball.radius * pose.translation_scale.w;
+#endif
+
+        return Aabb(
+            tra - Vector(rad),
+            tra + Vector(rad)
+        );
+    }
+
+    if ty == Shape::SHAPE_TYPE_CUBOID {
+        let cuboid = Shape::to_cuboid(shape);
+        let rotmat = Rot::toMatrix(pose.rotation);
+
+#if DIM == 2
+        // TODO: write a utility for abs(mat2x2).
+        let hext = mat2x2(abs(rotmat[0]), abs(rotmat[1])) * (cuboid.halfExtents * pose.scale);
+        let center = pose.translation;
+#else
+        // TODO: write a utility for abs(mat3x3).
+        let hext = mat3x3(abs(rotmat[0]), abs(rotmat[1]), abs(rotmat[2])) * (cuboid.halfExtents * pose.translation_scale.w);
+        let center = pose.translation_scale.xyz;
+#endif
+
+        return Aabb(
+            center - hext,
+            center + hext
+        );
+    }
+
+    if ty == Shape::SHAPE_TYPE_CAPSULE {
+        let capsule = Shape::to_capsule(shape);
+        // FIXME
+        return Aabb();
+    }
+
+#if DIM == 3
+    if ty == Shape::SHAPE_TYPE_CONE {
+        let cone = Shape::to_cone(shape);
+        // FIXME
+        return Aabb();
+    }
+
+    if ty == Shape::SHAPE_TYPE_CYLINDER {
+        let cylinder = Shape::to_cylinder(shape);
+        // FIXME
+        return Aabb();
+    }
+#endif
+
+    // TODO: not implemented.
+    return Aabb();
+}
+
+/// Are the two AABBs intersecting?
+fn check_intersection(aabb1: Aabb, aabb2: Aabb) -> bool {
+    return !(any(aabb2.maxs < aabb1.mins) || any(aabb1.maxs < aabb2.mins));
+}
+
+/// Merge two AABBs into a single one that tightly encloses both inputs.
+fn merge(aabb1: Aabb, aabb2: Aabb) -> Aabb {
+    return Aabb(min(aabb1.mins, aabb2.mins), max(aabb1.maxs, aabb2.maxs));
+}

--- a/crates/wgparry/src/bounding_volumes/mod.rs
+++ b/crates/wgparry/src/bounding_volumes/mod.rs
@@ -1,0 +1,10 @@
+//! Bounding volume data structures for collision detection acceleration.
+//!
+//! Bounding volumes are simple geometric shapes that enclose more complex objects.
+//! They enable fast broad-phase collision detection by providing cheap overlap tests
+//! before performing expensive narrow-phase collision detection.
+//!
+//! Only Axis-Aligned Bounding Boxes (AABB) are provided at the moment.
+mod aabb;
+
+pub use aabb::*;

--- a/crates/wgparry/src/broad_phase/brute_force_broad_phase.rs
+++ b/crates/wgparry/src/broad_phase/brute_force_broad_phase.rs
@@ -1,0 +1,96 @@
+//! Brute-force broad-phase collision detection.
+//!
+//! Tests all pairs of colliders for AABB overlap (O(n²) complexity). While not scalable
+//! for large scenes, the algorithm is highly parallelizable on GPU and can outperform more
+//! sophisticated algorithms for small to medium-sized simulations (< 1000 objects).
+//!
+//! The GPU implementation processes pairs in parallel, making effective use of GPU compute
+//! resources even though the algorithmic complexity is quadratic.
+
+use crate::bounding_volumes::WgAabb;
+use crate::math::GpuSim;
+use crate::shapes::{GpuShape, WgShape};
+use crate::{dim_shader_defs, substitute_aliases};
+use wgcore::indirect::{DispatchIndirectArgs, WgIndirect};
+
+#[cfg(feature = "dim2")]
+use nalgebra::Vector2;
+#[cfg(feature = "dim3")]
+use nalgebra::Vector4;
+use wgcore::kernel::KernelDispatch;
+use wgcore::tensor::{GpuScalar, GpuVector};
+use wgcore::{test_shader_compilation, Shader};
+use wgebra::{WgSim2, WgSim3};
+use wgpu::{ComputePass, ComputePipeline, Device};
+
+#[derive(Shader)]
+#[shader(
+    derive(WgSim3, WgSim2, WgShape, WgAabb, WgIndirect),
+    src = "./brute_force_broad_phase.wgsl",
+    shader_defs = "dim_shader_defs",
+    src_fn = "substitute_aliases",
+    composable = false
+)]
+/// GPU shader for brute-force broad-phase collision detection.
+///
+/// This shader tests all pairs of colliders for AABB overlap in parallel. While O(n²),
+/// it can be convenient for testing and debugging more sophisticated algorithms.
+pub struct WgBruteForceBroadPhase {
+    main: ComputePipeline,
+    reset: ComputePipeline,
+    init_indirect_args: ComputePipeline,
+    debug_compute_aabb: ComputePipeline, // TODO: remove this. For debugging only.
+}
+
+impl WgBruteForceBroadPhase {
+    const WORKGROUP_SIZE: u32 = 64;
+
+    /// Dispatches the brute-force broad-phase collision detection.
+    pub fn dispatch(
+        &self,
+        device: &Device,
+        pass: &mut ComputePass,
+        num_colliders: u32,
+        poses: &GpuVector<GpuSim>,
+        shapes: &GpuVector<GpuShape>,
+        num_shapes: &GpuScalar<u32>,
+        collision_pairs: &GpuVector<[u32; 2]>,
+        collision_pairs_len: &GpuScalar<u32>,
+        collision_pairs_indirect: &GpuScalar<DispatchIndirectArgs>,
+        #[cfg(feature = "dim2")] debug_aabb_mins: &GpuVector<Vector2<f32>>,
+        #[cfg(feature = "dim2")] debug_aabb_maxs: &GpuVector<Vector2<f32>>,
+        #[cfg(feature = "dim3")] debug_aabb_mins: &GpuVector<Vector4<f32>>,
+        #[cfg(feature = "dim3")] debug_aabb_maxs: &GpuVector<Vector4<f32>>,
+    ) {
+        KernelDispatch::new(device, pass, &self.reset)
+            .bind_at(0, [(collision_pairs_len.buffer(), 4)])
+            .dispatch(1);
+
+        KernelDispatch::new(device, pass, &self.main)
+            .bind0([
+                num_shapes.buffer(),
+                poses.buffer(),
+                shapes.buffer(),
+                collision_pairs.buffer(),
+                collision_pairs_len.buffer(),
+            ])
+            .dispatch(num_colliders.div_ceil(Self::WORKGROUP_SIZE));
+
+        KernelDispatch::new(device, pass, &self.init_indirect_args)
+            .bind_at(
+                0,
+                [
+                    (collision_pairs_len.buffer(), 4),
+                    (collision_pairs_indirect.buffer(), 5),
+                ],
+            )
+            .dispatch(1);
+
+        KernelDispatch::new(device, pass, &self.debug_compute_aabb)
+            .bind_at(0, [(poses.buffer(), 1), (shapes.buffer(), 2)])
+            .bind(1, [debug_aabb_mins.buffer(), debug_aabb_maxs.buffer()])
+            .dispatch(num_colliders.div_ceil(Self::WORKGROUP_SIZE));
+    }
+}
+
+test_shader_compilation!(WgBruteForceBroadPhase);

--- a/crates/wgparry/src/broad_phase/brute_force_broad_phase.wgsl
+++ b/crates/wgparry/src/broad_phase/brute_force_broad_phase.wgsl
@@ -1,0 +1,93 @@
+//! Brute Force Broad Phase Collision Detection
+//!
+//! This compute shader implements O(n²) all-pairs collision detection using AABBs.
+//! While not scalable to large scenes, it's very convenient for testing and debugging.
+//!
+//! Pipeline:
+//! 1. reset: Clears collision pair counter
+//! 2. main: Double-nested loop tests all pairs (i < j) for AABB overlap
+//! 3. init_indirect_args: Prepares indirect dispatch for narrow phase
+//!
+//! Buffers:
+//! - Input: num_colliders (uniform), poses, shapes (storage)
+//! - Output: collision_pairs (vec2<u32> array), collision_pairs_len (atomic counter)
+
+#import wgparry::shape as Shape;
+#import wgparry::bounding_volumes::aabb as Aabb;
+#import wgcore::indirect as Indirect;
+
+#if DIM == 2
+    #import wgebra::sim2 as Pose;
+#else
+    #import wgebra::sim3 as Pose;
+#endif
+
+@group(0) @binding(0)
+var<uniform> num_colliders: u32;
+@group(0) @binding(1)
+var<storage, read> poses: array<Transform>;
+@group(0) @binding(2)
+var<storage, read> shapes: array<Shape::Shape>;
+@group(0) @binding(3)
+var<storage, read_write> collision_pairs: array<vec2<u32>>;
+@group(0) @binding(4)
+var<storage, read_write> collision_pairs_len: atomic<u32>;
+@group(0) @binding(5)
+var<storage, read_write> collision_pairs_len_indirect_args: Indirect::DispatchIndirectArgs;
+
+@group(1) @binding(0)
+var<storage, read_write> debug_mins: array<Vector>;
+@group(1) @binding(1)
+var<storage, read_write> debug_maxs: array<Vector>;
+
+
+const WORKGROUP_SIZE: u32 = 64;
+
+@compute @workgroup_size(1, 1, 1)
+fn reset() {
+    collision_pairs_len = 0u;
+}
+
+@compute @workgroup_size(WORKGROUP_SIZE, 1, 1)
+fn debug_compute_aabb(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
+    let i = invocation_id.x;
+
+    if i < arrayLength(&debug_mins) {
+        let pose1 = poses[i];
+        let shape1 = shapes[i];
+        var aabb1 = Aabb::from_shape(pose1, shape1);
+        debug_mins[i] = aabb1.mins;
+        debug_maxs[i] = aabb1.maxs;
+    }
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn init_indirect_args() {
+    collision_pairs_len_indirect_args = Indirect::DispatchIndirectArgs(Indirect::div_ceil(collision_pairs_len, WORKGROUP_SIZE), 1, 1);
+}
+
+@compute @workgroup_size(WORKGROUP_SIZE, 1, 1)
+fn main(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
+    let num_threads = num_workgroups.x * WORKGROUP_SIZE * num_workgroups.y * num_workgroups.z;
+    for (var i = invocation_id.x; i < num_colliders; i += num_threads) {
+        let pose1 = poses[i];
+        let shape1 = shapes[i];
+
+        var aabb1 = Aabb::from_shape(pose1, shape1);
+        let prediction = 0.1;
+        let dilation = Vector(prediction); // TODO: should be configurable.
+        aabb1.mins -= dilation;
+        aabb1.maxs += dilation;
+
+        for (var j = i + 1u; j < num_colliders; j++) {
+            let pose2 = poses[j];
+            let shape2 = shapes[j];
+            let aabb2 = Aabb::from_shape(pose2, shape2);
+
+            if Aabb::check_intersection(aabb1, aabb2) {
+                let target_pair_index = atomicAdd(&collision_pairs_len, 1u);
+                collision_pairs[target_pair_index] = vec2(i, j);
+            }
+        }
+    }
+}

--- a/crates/wgparry/src/broad_phase/lbvh.rs
+++ b/crates/wgparry/src/broad_phase/lbvh.rs
@@ -1,0 +1,600 @@
+use crate::bounding_volumes::WgAabb;
+use crate::math::GpuSim;
+use crate::shapes::{GpuShape, WgShape};
+use crate::utils::{RadixSort, RadixSortWorkspace};
+use crate::{dim_shader_defs, substitute_aliases};
+use naga_oil::compose::ComposerError;
+use parry::bounding_volume::Aabb;
+use wgcore::indirect::{DispatchIndirectArgs, WgIndirect};
+
+#[cfg(feature = "dim2")]
+use nalgebra::Vector2;
+#[cfg(feature = "dim3")]
+use nalgebra::Vector4;
+use wgcore::kernel::KernelDispatch;
+use wgcore::tensor::{GpuScalar, GpuVector};
+use wgcore::Shader;
+use wgebra::WgSim3;
+use wgpu::{BufferUsages, ComputePass, ComputePipeline, Device};
+
+#[derive(Shader)]
+#[shader(
+    derive(WgSim3, WgShape, WgAabb, WgIndirect),
+    src = "./lbvh.wgsl",
+    src_fn = "substitute_aliases",
+    shader_defs = "dim_shader_defs",
+    composable = false
+)]
+/// GPU shader for Linear Bounding Volume Hierarchy (LBVH) construction and traversal.
+///
+/// Implements the Karras 2012 parallel LBVH construction algorithm on the GPU, providing
+/// O(n log n) collision detection suitable for large dynamic scenes.
+pub struct WgLbvh {
+    reset_collision_pairs: ComputePipeline,
+    compute_domain: ComputePipeline,
+    compute_morton: ComputePipeline,
+    build: ComputePipeline,
+    refit_leaves: ComputePipeline,
+    refit_internal: ComputePipeline,
+    #[allow(dead_code)]
+    refit: ComputePipeline,
+    find_collision_pairs: ComputePipeline,
+    init_indirect_args: ComputePipeline,
+}
+
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, Default)]
+#[repr(C)]
+/// A node in the LBVH binary tree structure.
+///
+/// Each node represents either:
+/// - **Leaf node**: Contains a single collider (when `left == right`)
+/// - **Internal node**: Contains references to two child nodes
+///
+/// The tree is built using Morton codes for spatial sorting, enabling cache-friendly
+/// traversal and efficient parallel construction.
+pub struct LbvhNode {
+    #[cfg(feature = "dim3")]
+    aabb_mins: Vector4<f32>,
+    #[cfg(feature = "dim3")]
+    aabb_maxs: Vector4<f32>,
+    #[cfg(feature = "dim2")]
+    aabb_mins: Vector2<f32>,
+    #[cfg(feature = "dim2")]
+    aabb_maxs: Vector2<f32>,
+    left: u32,
+    right: u32,
+    parent: u32,
+    refit_count: u32,
+}
+
+impl LbvhNode {
+    /// Extracts the AABB (axis-aligned bounding box) from this node.
+    ///
+    /// Returns a [`parry::bounding_volume::Aabb`] constructed from the node's min/max bounds.
+    #[cfg(feature = "dim3")]
+    pub fn aabb(&self) -> Aabb {
+        Aabb::new(self.aabb_mins.xyz().into(), self.aabb_maxs.xyz().into())
+    }
+
+    /// Extracts the AABB (axis-aligned bounding box) from this node.
+    ///
+    /// Returns a [`parry::bounding_volume::Aabb`] constructed from the node's min/max bounds.
+    #[cfg(feature = "dim2")]
+    pub fn aabb(&self) -> Aabb {
+        Aabb::new(self.aabb_mins.into(), self.aabb_maxs.into())
+    }
+}
+
+/// GPU-resident state for LBVH construction and queries.
+///
+/// Maintains all GPU buffers needed for building and querying the LBVH:
+/// - Morton codes and their sorted versions
+/// - Collider indices (sorted by Morton code)
+/// - The BVH tree structure itself
+/// - Radix sort workspace for Morton code sorting
+///
+/// Buffers automatically resize when the number of colliders changes.
+pub struct LbvhState {
+    buffer_usages: BufferUsages, // Just for debugging if we want COPY_SRC
+    #[cfg(feature = "dim3")]
+    domain_aabb: GpuScalar<[Vector4<f32>; 2]>,
+    #[cfg(feature = "dim2")]
+    domain_aabb: GpuScalar<[Vector2<f32>; 2]>,
+    n_sort: GpuScalar<u32>,
+    unsorted_morton_keys: GpuVector<u32>,
+    sorted_morton_keys: GpuVector<u32>,
+    unsorted_colliders: GpuVector<u32>,
+    sorted_colliders: GpuVector<u32>,
+    tree: GpuVector<LbvhNode>,
+    sort_workspace: RadixSortWorkspace,
+}
+
+/// High-level LBVH broad-phase interface (shaders only).
+///
+/// Provides the complete LBVH pipeline:
+/// 1. Compute AABBs and domain bounds
+/// 2. Generate Morton codes for spatial sorting
+/// 3. Sort colliders by Morton code
+/// 4. Build binary tree structure
+/// 5. Traverse tree to find collision pairs
+pub struct Lbvh {
+    shaders: WgLbvh,
+    sort: RadixSort,
+}
+
+impl LbvhState {
+    /// Creates a new LBVH state with default buffer usage flags.
+    ///
+    /// Initializes all buffers with `BufferUsages::STORAGE` flag for compute shader access.
+    pub fn new(device: &Device) -> Result<Self, ComposerError> {
+        Self::with_usages(device, BufferUsages::STORAGE)
+    }
+
+    /// Creates a new LBVH state with custom buffer usage flags.
+    ///
+    /// Allows specifying custom usage flags for debugging or special use cases
+    /// (e.g., adding `COPY_SRC` for buffer readback).
+    pub fn with_usages(device: &Device, usages: BufferUsages) -> Result<Self, ComposerError> {
+        Ok(Self {
+            n_sort: GpuScalar::init(device, 0, usages),
+            domain_aabb: GpuScalar::uninit(device, usages),
+            unsorted_morton_keys: GpuVector::uninit(device, 0, usages),
+            sorted_morton_keys: GpuVector::uninit(device, 0, usages),
+            unsorted_colliders: GpuVector::uninit(device, 0, usages),
+            sorted_colliders: GpuVector::uninit(device, 0, usages),
+            tree: GpuVector::uninit(device, 0, usages),
+            sort_workspace: RadixSortWorkspace::new(device),
+            buffer_usages: usages,
+        })
+    }
+
+    fn resize_buffers(&mut self, device: &Device, colliders_len: u32) {
+        if self.tree.len() < 2 * colliders_len as u64 {
+            self.unsorted_morton_keys =
+                GpuVector::uninit(device, colliders_len, self.buffer_usages);
+            self.sorted_morton_keys = GpuVector::uninit(device, colliders_len, self.buffer_usages);
+            let unsorted_colliders: Vec<_> = (0..colliders_len).collect();
+            self.unsorted_colliders =
+                GpuVector::init(device, &unsorted_colliders, self.buffer_usages);
+            self.sorted_colliders = GpuVector::uninit(device, colliders_len, self.buffer_usages);
+            self.tree = GpuVector::uninit(device, 2 * colliders_len, self.buffer_usages);
+
+            // FIXME: we should instead write the len into the existing buffer at each frame
+            //        to handle dynamic body/collider insertion/removal.
+            self.n_sort = GpuScalar::init(device, colliders_len, self.buffer_usages);
+        }
+    }
+}
+
+impl Lbvh {
+    const WORKGROUP_SIZE: u32 = 64;
+
+    /// Creates a new LBVH instance by compiling shaders on the given device.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if shader compilation fails.
+    pub fn from_device(device: &Device) -> Result<Self, ComposerError> {
+        Ok(Self {
+            shaders: WgLbvh::from_device(device)?,
+            sort: RadixSort::from_device(device)?,
+        })
+    }
+
+    /// Rebuilds the LBVH tree from current collider poses and shapes.
+    ///
+    /// This method:
+    /// 1. Computes AABBs for all colliders
+    /// 2. Calculates the bounding domain
+    /// 3. Generates Morton codes for spatial sorting
+    /// 4. Sorts colliders by Morton code using radix sort
+    /// 5. Builds the binary BVH tree structure
+    ///
+    /// Should be called each frame before [`find_pairs`](Self::find_pairs) if colliders have moved.
+    ///
+    /// # Parameters
+    ///
+    /// - `device`: The GPU device
+    /// - `pass`: Active compute pass to record commands into
+    /// - `state`: Mutable LBVH state (buffers may be resized if needed)
+    /// - `colliders_len`: Number of colliders to process
+    /// - `poses`: Collider world-space poses
+    /// - `shapes`: Collider shapes
+    /// - `num_shapes`: Scalar buffer containing the collider count
+    pub fn update_tree(
+        &self,
+        device: &Device,
+        pass: &mut ComputePass<'_>,
+        state: &mut LbvhState,
+        colliders_len: u32,
+        poses: &GpuVector<GpuSim>,
+        shapes: &GpuVector<GpuShape>,
+        num_shapes: &GpuScalar<u32>,
+    ) {
+        state.resize_buffers(device, colliders_len);
+
+        // Bind group 0.
+        let num_colliders = (num_shapes.buffer(), 0);
+        let poses = (poses.buffer(), 1);
+        let shapes = (shapes.buffer(), 2);
+        let domain_aabb = (state.domain_aabb.buffer(), 6);
+        let unsorted_morton_keys = (state.unsorted_morton_keys.buffer(), 7);
+        let sorted_morton_keys = (state.sorted_morton_keys.buffer(), 7);
+        let sorted_colliders = (state.sorted_colliders.buffer(), 8);
+        let tree = (state.tree.buffer(), 9);
+
+        // Dispatch everything.
+        KernelDispatch::new(device, pass, &self.shaders.compute_domain)
+            .bind_at(0, [num_colliders, poses, domain_aabb])
+            .dispatch(1);
+
+        KernelDispatch::new(device, pass, &self.shaders.compute_morton)
+            .bind_at(0, [num_colliders, poses, domain_aabb, unsorted_morton_keys])
+            .dispatch(colliders_len.div_ceil(Self::WORKGROUP_SIZE));
+
+        self.sort.dispatch(
+            device,
+            pass,
+            &mut state.sort_workspace,
+            &state.unsorted_morton_keys,
+            &state.unsorted_colliders,
+            &state.n_sort,
+            32,
+            &state.sorted_morton_keys,
+            &state.sorted_colliders,
+        );
+
+        KernelDispatch::new(device, pass, &self.shaders.build)
+            .bind_at(0, [num_colliders, sorted_morton_keys, tree])
+            .dispatch((colliders_len - 1).div_ceil(Self::WORKGROUP_SIZE));
+
+        KernelDispatch::new(device, pass, &self.shaders.refit_leaves)
+            .bind_at(0, [num_colliders, tree, poses, shapes, sorted_colliders])
+            .dispatch(colliders_len.div_ceil(Self::WORKGROUP_SIZE));
+
+        KernelDispatch::new(device, pass, &self.shaders.refit_internal)
+            .bind_at(0, [num_colliders, tree])
+            .dispatch(1);
+        // .dispatch(colliders_len.div_ceil(Self::WORKGROUP_SIZE));
+
+        // KernelDispatch::new(device, pass, &self.shaders.refit)
+        //     .bind_at(0, [num_colliders, tree, poses, shapes, sorted_colliders])
+        //     .dispatch(colliders_len.div_ceil(Self::WORKGROUP_SIZE));
+    }
+
+    /// Traverses the LBVH tree to find potentially colliding pairs.
+    ///
+    /// After the tree has been built with [`update_tree`](Self::update_tree), this method
+    /// traverses it to identify pairs of colliders whose AABBs overlap.
+    ///
+    /// # Parameters
+    ///
+    /// - `device`: The GPU device
+    /// - `pass`: Active compute pass to record commands into
+    /// - `state`: LBVH state containing the built tree
+    /// - `colliders_len`: Number of colliders in the scene
+    /// - `num_shapes`: Scalar buffer containing the collider count
+    /// - `collision_pairs`: Output buffer for potentially colliding pairs
+    /// - `collision_pairs_len`: Output count of collision pairs found
+    /// - `collision_pairs_indirect`: Indirect dispatch args for subsequent kernels
+    pub fn find_pairs(
+        &self,
+        device: &Device,
+        pass: &mut ComputePass<'_>,
+        state: &mut LbvhState,
+        colliders_len: u32,
+        num_shapes: &GpuScalar<u32>,
+        collision_pairs: &GpuVector<[u32; 2]>,
+        collision_pairs_len: &GpuScalar<u32>,
+        collision_pairs_indirect: &GpuScalar<DispatchIndirectArgs>,
+    ) {
+        // Bind group 0.
+        let num_colliders = (num_shapes.buffer(), 0);
+        let collision_pairs = (collision_pairs.buffer(), 3);
+        let collision_pairs_len = (collision_pairs_len.buffer(), 4);
+        let collision_pairs_indirect = (collision_pairs_indirect.buffer(), 5);
+        let tree = (state.tree.buffer(), 9);
+
+        KernelDispatch::new(device, pass, &self.shaders.reset_collision_pairs)
+            .bind_at(0, [collision_pairs_len])
+            .dispatch(1);
+
+        KernelDispatch::new(device, pass, &self.shaders.find_collision_pairs)
+            .bind_at(
+                0,
+                [num_colliders, collision_pairs_len, collision_pairs, tree],
+            )
+            .dispatch(colliders_len.div_ceil(Self::WORKGROUP_SIZE));
+
+        KernelDispatch::new(device, pass, &self.shaders.init_indirect_args)
+            .bind_at(0, [collision_pairs_len, collision_pairs_indirect])
+            .dispatch(1);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::math::Isometry;
+    use na::Similarity3;
+    use parry::bounding_volume::BoundingVolume;
+    use wgcore::gpu::GpuInstance;
+    use wgcore::kernel::CommandEncoderExt;
+
+    #[futures_test::test]
+    #[serial_test::serial]
+    async fn tree_construction() {
+        let storage = BufferUsages::STORAGE | BufferUsages::COPY_SRC;
+        let gpu = GpuInstance::new().await.unwrap();
+        let mut lbvh = Lbvh::with_usages(gpu.device(), storage).unwrap();
+        const LEN: u32 = 1000;
+        let poses: Vec<_> = (0..LEN)
+            .map(|i| {
+                Similarity3::new(
+                    -Vector::new(i as f32, (i as f32).sin(), (i as f32).cos()),
+                    na::zero(),
+                    1.0,
+                )
+            })
+            .collect();
+        let shapes: Vec<_> = vec![GpuShape::ball(0.5); LEN as usize];
+
+        let gpu_poses = GpuVector::init(gpu.device(), &poses, storage);
+        let gpu_shapes = GpuVector::init(gpu.device(), &shapes, storage);
+        let gpu_num_shapes = GpuScalar::init(
+            gpu.device(),
+            LEN,
+            BufferUsages::STORAGE | BufferUsages::UNIFORM,
+        );
+        let gpu_collision_pairs = GpuVector::uninit(gpu.device(), 10000, storage);
+        let gpu_collision_pairs_len = GpuScalar::init(gpu.device(), 0, storage);
+        let gpu_collision_pairs_indirect = GpuScalar::uninit(gpu.device(), storage);
+
+        let mut encoder = gpu
+            .device()
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let mut pass = encoder.compute_pass("", None);
+        lbvh.launch(
+            gpu.device(),
+            &mut pass,
+            LEN,
+            &gpu_poses,
+            &gpu_shapes,
+            &gpu_num_shapes,
+            &gpu_collision_pairs,
+            &gpu_collision_pairs_len,
+            &gpu_collision_pairs_indirect,
+        );
+        drop(pass);
+        gpu.queue().submit(Some(encoder.finish()));
+
+        // Check result of `compute_domain`.
+        let domain = lbvh.domain_aabb.slow_read(&gpu).await[0];
+        let pts: Vec<_> = poses
+            .iter()
+            .map(|p| p.isometry.translation.vector.into())
+            .collect();
+        let domain_cpu = Aabb::from_points(&pts);
+        assert_eq!(domain_cpu.mins.coords, domain[0].xyz());
+        assert_eq!(domain_cpu.maxs.coords, domain[1].xyz());
+
+        // Check result of `compute_morton`.
+        let mortons = lbvh.unsorted_morton_keys.slow_read(&gpu).await;
+        let mut morton_cpu: Vec<_> = pts
+            .iter()
+            .map(|pt| {
+                let normalized = (pt - domain_cpu.mins).component_div(&domain_cpu.extents());
+                morton(normalized.x, normalized.y, normalized.z)
+            })
+            .collect();
+        assert_eq!(morton_cpu, mortons);
+
+        // Check result of `sort`.
+        let mut sorted_colliders_cpu: Vec<_> = (0..LEN).collect();
+        sorted_colliders_cpu.sort_by_key(|i| morton_cpu[*i as usize]);
+        morton_cpu.sort();
+        let mut sorted_mortons = lbvh.sorted_morton_keys.slow_read(&gpu).await;
+        let sorted_colliders = lbvh.sorted_colliders.slow_read(&gpu).await;
+        assert_eq!(sorted_mortons, morton_cpu);
+        assert_eq!(sorted_colliders, sorted_colliders_cpu);
+
+        // Check result of `build`.
+        let mut tree = lbvh.tree.slow_read(&gpu).await;
+
+        {
+            // Check that a traversal covers all the nodes and that there is no loop.
+            let mut visited = vec![false; tree.len()];
+            let mut stack = vec![0];
+            let mut loops = 0;
+            while let Some(curr) = stack.pop() {
+                loops += 1;
+                let node = &tree[curr];
+                assert!(!visited[curr]);
+                visited[curr] = true;
+                if curr < LEN as usize - 1 {
+                    // This is an internal node
+                    stack.push(node.left as usize);
+                    stack.push(node.right as usize);
+                }
+            }
+
+            assert_eq!(visited.iter().filter(|e| **e).count(), LEN as usize * 2 - 1);
+
+            // Check parent pointers.
+            for (i, node) in tree[..LEN as usize - 1].iter().enumerate() {
+                assert_eq!(tree[node.right as usize].parent, i as u32);
+                assert_eq!(tree[node.left as usize].parent, i as u32);
+            }
+        }
+
+        // Check result of `refit`.
+        {
+            // Check that the leaf AABBs are correct.
+            let first_leaf_id = LEN - 1;
+            for i in 0..LEN {
+                let node = &tree[(first_leaf_id + i) as usize];
+                let collider = sorted_colliders[i as usize];
+                assert_eq!(
+                    node.aabb(),
+                    Aabb::from_half_extents(
+                        poses[collider as usize].isometry.translation.vector.into(),
+                        Vector::repeat(0.5)
+                    )
+                );
+            }
+
+            // Check that each AABB encloses the AABB of its children.
+            for i in 0..LEN - 1 {
+                let node = &tree[i as usize];
+                let left = &tree[node.left as usize];
+                let right = &tree[node.right as usize];
+                println!("Testing: {} -> ({},{})", i, node.left, node.right);
+
+                println!("Node: {:?}", node.aabb());
+                println!("Left: {:?}", left.aabb());
+                println!("Right: {:?}", right.aabb());
+                assert_eq!(node.aabb(), left.aabb().merged(&right.aabb()));
+            }
+        }
+    }
+
+    // Expands a 10-bit integer into 30 bits
+    // by inserting 2 zeros after each bit.
+    fn expandBits(v: u32) -> u32 {
+        let mut vv = (v * 0x00010001) & 0xFF0000FF;
+        vv = (vv * 0x00000101) & 0x0F00F00F;
+        vv = (vv * 0x00000011) & 0xC30C30C3;
+        vv = (vv * 0x00000005) & 0x49249249;
+        vv
+    }
+
+    // Calculates a 30-bit Morton code for the
+    // given 3D point located within the unit cube [0,1].
+    fn morton(x: f32, y: f32, z: f32) -> u32 {
+        let scaled_x = (x * 1024.0).max(0.0).min(1023.0);
+        let scaled_y = (y * 1024.0).max(0.0).min(1023.0);
+        let scaled_z = (z * 1024.0).max(0.0).min(1023.0);
+        let xx = expandBits(scaled_x as u32);
+        let yy = expandBits(scaled_y as u32);
+        let zz = expandBits(scaled_z as u32);
+        xx * 4 + yy * 2 + zz
+    }
+    //
+    // struct PrefixLen<'a> {
+    //     morton_keys: &'a [u32],
+    //     num_colliders: usize,
+    // }
+    //
+    // impl<'a> PrefixLen<'a> {
+    //     fn morton_at(&self, i: i32) -> i32 {
+    //         // TODO PERF: would it be meaningful to add sentinels at the begining
+    //         //            and end of the morton_keys array so we don’t have to check
+    //         //            bounds?
+    //         if i < 0 || i > self.num_colliders as i32 - 1 {
+    //             return -1;
+    //         } else {
+    //             return self.morton_keys[i as usize] as i32;
+    //         }
+    //     }
+    //
+    //     fn prefix_len(&self, curr_key: u32, other_index: i32) -> i32 {
+    //         let other_key = self.morton_at(other_index);
+    //         (curr_key as i32 ^ other_key).leading_zeros() as i32
+    //     }
+    // }
+    //
+    // /// Builds each node of the tree in parallel.
+    // ///
+    // /// This only computes the tree topology (children and parent pointers).
+    // /// This doesn’t update the bounding boxes. Call `refit` for updating bounding boxes!
+    // fn build(tree: &mut [LbvhNode], num_colliders: usize, morton_keys: &[u32]) {
+    //     let num_internal_nodes = num_colliders - 1;
+    //     let first_leaf_id = num_internal_nodes;
+    //     let pl = PrefixLen {
+    //         morton_keys,
+    //         num_colliders,
+    //     };
+    //
+    //     for i in 0..num_internal_nodes {
+    //         // Determine the direction of the range (+1 or -1).
+    //         let ii = i as i32;
+    //         let curr_key = morton_keys[i];
+    //         let d = (pl.prefix_len(curr_key, ii + 1) - pl.prefix_len(curr_key, ii - 1)).signum();
+    //
+    //         // Compute upper bound for the length of the range.
+    //         let delta_min = pl.prefix_len(curr_key, ii - d);
+    //         let mut l = 0;
+    //         while pl.prefix_len(curr_key, ii + (l + 1) * d) > delta_min {
+    //             l += 1;
+    //         }
+    //
+    //         let mut lmax = 2; // TODO PERF: start at 128 ?
+    //         while pl.prefix_len(curr_key, ii + lmax * d) > delta_min {
+    //             lmax *= 2; // TODO PERF: multiply by 4 instead of 2 ?
+    //         }
+    //
+    //         // Find the other end using binary search.
+    //         let mut l = 0;
+    //         let mut t = lmax / 2;
+    //         while t >= 1 {
+    //             if pl.prefix_len(curr_key, ii + (l + t) * d) > delta_min {
+    //                 l += t;
+    //             }
+    //
+    //             t /= 2;
+    //         }
+    //
+    //         let j = ii + l * d;
+    //
+    //         // Find the split position using binary search.
+    //         let delta_node = pl.prefix_len(curr_key, j);
+    //
+    //         let mut s = 0;
+    //         while pl.prefix_len(curr_key, ii + (s + 1) * d) > delta_node {
+    //             s += 1;
+    //         }
+    //         let seq_s = s;
+    //
+    //         let mut s = 0;
+    //         let mut t = (l as u32).div_ceil(2) as i32;
+    //         loop {
+    //             if pl.prefix_len(curr_key, ii + (s + t) * d) > delta_node {
+    //                 s += t;
+    //             }
+    //
+    //             if t == 1 {
+    //                 break;
+    //             } else {
+    //                 t = (t as u32).div_ceil(2) as i32;
+    //             }
+    //         }
+    //
+    //         println!(
+    //             "base t: {}, delta: {delta_node}, plen seq: {}, plen: {}",
+    //             l / 2,
+    //             pl.prefix_len(curr_key, ii + seq_s * d),
+    //             pl.prefix_len(curr_key, ii + s * d)
+    //         );
+    //         assert_eq!(seq_s, s);
+    //
+    //         let gamma = ii + s * d + d.min(0);
+    //
+    //         // Output child and parent pointers.
+    //         let left = if ii.min(j) == gamma {
+    //             first_leaf_id as i32 + gamma
+    //         } else {
+    //             gamma
+    //         };
+    //         let right = if ii.max(j) == gamma + 1 {
+    //             first_leaf_id as i32 + gamma + 1
+    //         } else {
+    //             gamma + 1
+    //         };
+    //         tree[i].left = left as u32;
+    //         tree[i].right = right as u32;
+    //         tree[i].refit_count = 0; // This is a good opportunity to reset the `refit_count` too.
+    //         tree[left as usize].parent = i as u32;
+    //         tree[right as usize].parent = i as u32;
+    //     }
+    // }
+}

--- a/crates/wgparry/src/broad_phase/lbvh.wgsl
+++ b/crates/wgparry/src/broad_phase/lbvh.wgsl
@@ -1,0 +1,607 @@
+//! Linear Bounding Volume Hierarchy (LBVH) Broad Phase
+//!
+//! This module implements a GPU-based LBVH construciton and traversal. It is based on
+//! the paper: https://research.nvidia.com/sites/default/files/publications/karras2012hpg_paper.pdf
+//! The LBVH provides O(n log n) construction and O(n log n) query complexity.
+//!
+//! Pipeline stages:
+//! 1. compute_domain: Parallel reduction to find AABB of all collider positions.
+//! 2. compute_morton: Assigns 30-bit (3D) or 20-bit (2D) Morton codes to colliders.
+//! 3. [External radix sort]: Sorts colliders by Morton code.
+//! 4. build: Constructs binary tree topology in parallel (Karras algorithm).
+//! 5. refit_leaves: Computes leaf AABBs from shapes.
+//! 6. refit_internal: Bottom-up AABB propagation using atomic synchronization.
+//! 7. find_collision_pairs: Tree traversal for each collider to find intersections.
+//!
+//! Data structures:
+//! - LbvhNode: Binary tree node with AABB + left/right/parent pointers + refit counter
+//! - Tree layout: Internal nodes [0..n-1], leaves [n..2n-1]
+//! - Leaf nodes store collider index in 'left' field
+//!
+//! Key algorithms:
+//! - Karras 2012: Maximizing Parallelism in the Construction of BVHs, Octrees, and k-d Trees
+//! - Atomic refitting: Each leaf spawns thread that propagates upward, atomics ensure parent
+//!   waits for both children
+//! - Stack-based traversal: 64-entry stack for tree queries
+//!
+//! Morton encoding:
+//! - 3D: 10 bits per axis, interleaved (xxx...yyy...zzz -> xyzxyz...)
+//! - 2D: 10 bits per axis (TODO: could be extended to 16+16)
+//!
+//! Performance:
+//! - Construction: O(n log n)
+//! - Queries: O(n log n) total (O(log n) per collider on average)
+//!
+//! Implementation notes:
+//! - Web compatibility: Uses uniform control flow version of refit_internal
+//! - Native version (without uniform control flow for atomics) available via NATIVE=1 define
+
+#import wgparry::shape as Shape;
+#import wgparry::bounding_volumes::aabb as Aabb;
+#import wgcore::indirect as Indirect;
+
+#if DIM == 2
+    #import wgebra::sim2 as Pose;
+#else
+    #import wgebra::sim3 as Pose;
+#endif
+
+
+@group(0) @binding(0)
+var<uniform> num_colliders: u32;
+@group(0) @binding(1)
+var<storage, read> poses: array<Transform>;
+@group(0) @binding(2)
+var<storage, read> shapes: array<Shape::Shape>;
+@group(0) @binding(3)
+var<storage, read_write> collision_pairs: array<vec2<u32>>;
+@group(0) @binding(4)
+var<storage, read_write> collision_pairs_len: atomic<u32>;
+@group(0) @binding(5)
+var<storage, read_write> collision_pairs_len_indirect_args: Indirect::DispatchIndirectArgs;
+
+@group(0) @binding(6)
+var<storage, read_write> domain_aabb: Aabb::Aabb;
+@group(0) @binding(7)
+var<storage, read_write> morton_keys: array<u32>;
+@group(0) @binding(8)
+var<storage, read_write> sorted_colliders: array<u32>;
+@group(0) @binding(9)
+var<storage, read_write> tree: array<LbvhNode>;
+
+/// A node in the Linear BVH tree.
+///
+/// The tree has n-1 internal nodes and n leaf nodes. Internal nodes are stored
+/// in indices [0..n-1], leaf nodes in [n..2n].
+///
+/// For internal nodes:
+/// - left/right point to child nodes (may be internal or leaf)
+/// - parent points to parent internal node (0 for root)
+/// - refit_count tracks how many children have updated this node's AABB
+///
+/// For leaf nodes:
+/// - left stores the collider index
+/// - right is unused
+/// - parent points to parent internal node
+/// - refit_count is unused
+struct LbvhNode {
+    /// Axis-aligned bounding box for this node's subtree.
+    aabb: Aabb::Aabb,
+    /// Left child index (internal) or collider index (leaf).
+    left: u32,
+    /// Right child index (internal nodes only).
+    right: u32,
+    /// Parent node index.
+    parent: u32,
+    /// Atomic counter for bottom-up refitting (0, 1, or 2).
+    /// When a thread arrives at a node, it atomically increments this.
+    /// If the old value was 0, the thread stops (sibling hasn't arrived yet).
+    /// If the old value was 1, the thread continues upward (both children ready).
+    refit_count: atomic<u32>,
+}
+
+const WORKGROUP_SIZE: u32 = 64;
+// NOTE: if this const is modified, don’t forget to adjust accordingly
+//       the number of calls to `reduce` in `compute_domain`.
+const REDUCTION_WORKGROUP_SIZE: u32 = 128;
+
+// NOTE: the workspaces are used only by `compute_domain` for the min/max reduction.
+var<workgroup> workspace_mins: array<Vector, REDUCTION_WORKGROUP_SIZE>;
+var<workgroup> workspace_maxs: array<Vector, REDUCTION_WORKGROUP_SIZE>;
+
+fn reduce(thread_id: u32, stride: u32) {
+    if thread_id < stride {
+        workspace_mins[thread_id] = min(workspace_mins[thread_id], workspace_mins[thread_id + stride]);
+        workspace_maxs[thread_id] = max(workspace_maxs[thread_id], workspace_maxs[thread_id + stride]);
+    }
+    workgroupBarrier();
+}
+
+/// Runs a reduction to compute the AABB of the collider positions.
+/// Needs to be called with a single workgroup.
+@compute @workgroup_size(REDUCTION_WORKGROUP_SIZE, 1, 1)
+fn compute_domain(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
+    let thread_id = invocation_id.x;
+    workspace_mins[thread_id] = Vector(1.0e20);
+    workspace_maxs[thread_id] = -Vector(1.0e20);
+
+    for (var i = thread_id; i < num_colliders; i += REDUCTION_WORKGROUP_SIZE) {
+#if DIM == 2
+        let val_i = poses[i].translation;
+#else
+        let val_i = poses[i].translation_scale.xyz;
+#endif
+        workspace_mins[thread_id] = min(workspace_mins[thread_id], val_i);
+        workspace_maxs[thread_id] = max(workspace_maxs[thread_id], val_i);
+    }
+
+    workgroupBarrier();
+
+    reduce(thread_id, 64u);
+    reduce(thread_id, 32u);
+    reduce(thread_id, 16u);
+    reduce(thread_id, 8u);
+    reduce(thread_id, 4u);
+    reduce(thread_id, 2u);
+    reduce(thread_id, 1u);
+
+    if thread_id == 0u {
+        domain_aabb.mins = workspace_mins[0];
+        domain_aabb.maxs = workspace_maxs[0];
+    }
+}
+
+@compute @workgroup_size(WORKGROUP_SIZE, 1, 1)
+fn compute_morton(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
+    // NOTE: for simplicity we compute the morton key of the collider position instead of
+    //       the collider shape’s AABB center. We might want to revisit that in the future
+    //       once we start adding more complex shapes.
+    let num_threads = num_workgroups.x * WORKGROUP_SIZE * num_workgroups.y * num_workgroups.z;
+
+    for (var i = invocation_id.x; i < num_colliders; i += num_threads) {
+#if DIM == 2
+        let center = poses[i].translation;
+#else
+        let center = poses[i].translation_scale.xyz;
+#endif
+
+        let normalized = (center - domain_aabb.mins) / (domain_aabb.maxs - domain_aabb.mins);
+        let morton_key = morton(normalized);
+        morton_keys[i] = morton_key;
+    }
+}
+
+/// Builds each node of the tree in parallel.
+///
+/// This only computes the tree topology (children and parent pointers).
+/// This doesn’t update the bounding boxes. Call `refit` for updating bounding boxes!
+@compute @workgroup_size(WORKGROUP_SIZE, 1, 1)
+fn build(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
+    let num_threads = num_workgroups.x * WORKGROUP_SIZE * num_workgroups.y * num_workgroups.z;
+    let num_internal_nodes = num_colliders - 1u;
+    let first_leaf_id = num_internal_nodes;
+
+    for (var i = invocation_id.x; i < num_internal_nodes; i += num_threads) {
+        // Determine the direction of the range (+1 or -1).
+        let ii = i32(i);
+        let curr_key = morton_keys[i];
+        let d = sign(prefix_len(curr_key, ii, ii + 1) - prefix_len(curr_key, ii, ii - 1));
+
+        // Compute upper bound for the length of the range.
+        let delta_min = prefix_len(curr_key, ii, ii - d);
+        var lmax = 2; // TODO PERF: start at 128 ?
+
+        while prefix_len(curr_key, ii, ii + lmax * d) > delta_min {
+            lmax *= 2; // TODO PERF: multiply by 4 instead of 2 ?
+        }
+
+        // Find the other end using binary search.
+        var l = 0;
+        for (var t = lmax / 2; t >= 1; t /= 2) {
+            if prefix_len(curr_key, ii, ii + (l + t) * d) > delta_min {
+                l += t;
+            }
+        }
+        let j = ii + l * d;
+
+        // Find the split position using binary search.
+        let delta_node = prefix_len(curr_key, ii, j);
+        var s = 0;
+        var t = div_ceil(l, 2);
+
+        loop {
+            if prefix_len(curr_key, ii, ii + (s + t) * d) > delta_node {
+                s += t;
+            }
+
+            if t <= 1 {
+                break;
+            }
+
+            t = div_ceil(t, 2);
+        }
+
+        let gamma  = ii + s * d + min(d, 0);
+
+        // Output child and parent pointers.
+        let left = select(gamma, i32(first_leaf_id) + gamma, min(ii, j) == gamma);
+        let right = select(gamma + 1, i32(first_leaf_id) + gamma + 1, max(ii, j) == gamma + 1);
+        tree[i].left = u32(left);
+        tree[i].right = u32(right);
+        tree[i].refit_count = 0u; // Might as well reset the refit count here.
+        tree[left].parent = i;
+        tree[right].parent = i;
+    }
+}
+
+fn prefix_len(curr_key: u32, curr_index: i32, other_index: i32) -> i32 {
+    if other_index < 0 || other_index > i32(num_colliders) - 1 {
+        return -1;
+    }
+
+    let other_key = morton_at(other_index);
+    let morton_prefix_len = countLeadingZeros(i32(curr_key) ^ other_key);
+    // Fallback to indices if the morton keys are equal.
+    let fallback_prefix_len = 32 + countLeadingZeros(curr_index ^ other_index);
+    return select(fallback_prefix_len, morton_prefix_len, i32(curr_key) != other_key);
+}
+
+fn morton_at(i: i32) -> i32 {
+    // TODO PERF: would it be meaningful to add sentinels at the begining
+    //            and end of the morton_keys array so we don’t have to check
+    //            bounds?
+    if i < 0 || i > i32(num_colliders) - 1 {
+        return -1;
+    } else {
+        return i32(morton_keys[u32(i)]);
+    }
+}
+
+@compute @workgroup_size(WORKGROUP_SIZE, 1, 1)
+fn refit_leaves(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
+    // TODO PERF: we could use shared memory atomics between threads belonging to the same
+    //            workgroup.
+    // Bottom-up refit. Leaf index starts at `num_colliders`.
+    let num_threads = num_workgroups.x * WORKGROUP_SIZE * num_workgroups.y * num_workgroups.z;
+    let first_leaf_id = num_colliders - 1;
+
+    for (var i = invocation_id.x; i < num_colliders; i += num_threads) {
+        let curr_leaf_id = first_leaf_id + i;
+        let leaf_collider = sorted_colliders[i];
+        let leaf_pose = poses[leaf_collider];
+        let leaf_shape = shapes[leaf_collider];
+
+        tree[curr_leaf_id].aabb = Aabb::from_shape(leaf_pose, leaf_shape);
+        tree[curr_leaf_id].left = leaf_collider;
+    }
+}
+
+// TODO: benchmark to see if we shouldn’t just use the non-native version.
+#if NATIVE == 1
+// FIXME: original version that doesn’t work on the web because control flow
+// NOTE PERF: this function runs the refit with a single workgroup to work around the lack
+//            of strong memory ordering semantic in WGSL for the `atomicAdd`. If we could
+//            have non-relaxed ordering, we could just use `refit` instead.
+@compute @workgroup_size(256, 1, 1)
+fn refit_internal(@builtin(local_invocation_id) local_id: vec3<u32>) {
+    // TODO PERF: we could use shared memory atomics between threads belonging to the same
+    //            workgroup.
+    // Bottom-up refit. Leaf index starts at `num_colliders`.
+    let num_threads = 256u;
+    let first_leaf_id = num_colliders - 1;
+
+    for (var i = local_id.x; i < num_colliders; i += num_threads) {
+        let curr_leaf_id = first_leaf_id + i;
+        var curr_id = tree[curr_leaf_id].parent;
+
+        loop {
+            let refit_count = atomicAdd(&tree[curr_id].refit_count, 1u);
+
+            if refit_count == 0 {
+                // If `refit_count` was 0 then the other thread hasn’t reached this node
+                // yet and the sibbling aabb might not be available yet.
+                // Stop the propagation to the parents here, the other thread will do it.
+                break;
+            } else {
+                // If `refit_count` was 1 then the other thread has already reached this node
+                // and we know the sibblings aabb is available. So we can continue the propagation.
+
+                // TODO PERF: instead of re-reading both aabbs, we could keep the aabb from the
+                //            previous loop so we don’t have to re-fetch one of the two aabbs.
+                let left = tree[tree[curr_id].left].aabb;
+                let right = tree[tree[curr_id].right].aabb;
+                tree[curr_id].aabb = Aabb::merge(left, right);
+
+                if curr_id == 0 {
+                    // We reached the root, can’t go higher.
+                    break;
+                }
+            }
+
+            curr_id = tree[curr_id].parent;
+            workgroupBarrier();
+        }
+    }
+}
+#else
+// NOTE PERF: this function runs the refit with a single workgroup to work around the lack
+//            of strong memory ordering semantic in WGSL for the `atomicAdd`. If we could
+//            have non-relaxed ordering, we could just use `refit` instead.
+@compute @workgroup_size(256, 1, 1)
+fn refit_internal(@builtin(local_invocation_id) local_id: vec3<u32>) {
+    // TODO PERF: we could use shared memory atomics between threads belonging to the same
+    //            workgroup.
+    // Bottom-up refit. Leaf index starts at `num_colliders`.
+    let num_threads = 256u;
+    let first_leaf_id = num_colliders - 1;
+
+    // All threads must execute the same number of outer loop iterations for uniform control flow.
+    let num_iterations = (num_colliders + num_threads - 1u) / num_threads;
+
+    for (var iter = 0u; iter < num_iterations; iter++) {
+        let i = local_id.x + iter * num_threads;
+        var thread_is_active = i < num_colliders;
+
+        var curr_id = 0u;
+        if thread_is_active {
+            let curr_leaf_id = first_leaf_id + i;
+            curr_id = tree[curr_leaf_id].parent;
+        }
+
+        // Process the tree level by level with uniform barriers.
+        // Maximum tree depth is log2(num_colliders), but we use 32 as a safe upper bound.
+        for (var level = 0u; level < 32u; level++) {
+            if thread_is_active {
+                let refit_count = atomicAdd(&tree[curr_id].refit_count, 1u);
+
+                if refit_count == 0u {
+                    // If `refit_count` was 0 then the other thread hasn't reached this node
+                    // yet and the sibbling aabb might not be available yet.
+                    // Stop the propagation to the parents here, the other thread will do it.
+                    thread_is_active = false;
+                } else {
+                    // If `refit_count` was 1 then the other thread has already reached this node
+                    // and we know the sibblings aabb is available. So we can continue the propagation.
+
+                    // TODO PERF: instead of re-reading both aabbs, we could keep the aabb from the
+                    //            previous loop so we don't have to re-fetch one of the two aabbs.
+                    let left = tree[tree[curr_id].left].aabb;
+                    let right = tree[tree[curr_id].right].aabb;
+                    tree[curr_id].aabb = Aabb::merge(left, right);
+
+                    if curr_id == 0u {
+                        // We reached the root, can't go higher.
+                        thread_is_active = false;
+                    } else {
+                        curr_id = tree[curr_id].parent;
+                    }
+                }
+            }
+
+            // Barrier ensures all AABB writes are complete before the next iteration's atomics.
+            workgroupBarrier();
+        }
+    }
+}
+#endif
+
+// NOTE PERF: this function runs the refit with a single workgroup to work around the lack
+//            of strong memory ordering semantic in WGSL for the `atomicAdd`. If we could
+//            have non-relaxed ordering, we could just use `refit` instead.
+@compute @workgroup_size(WORKGROUP_SIZE, 1, 1)
+fn refit_internal_requirerings_strong_atomics(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
+    // TODO PERF: we could use shared memory atomics between threads belonging to the same
+    //            workgroup.
+    // Bottom-up refit. Leaf index starts at `num_colliders`.
+    if invocation_id.x >= num_colliders {
+        return;
+    }
+
+    let first_leaf_id = num_colliders - 1;
+    let curr_leaf_id = first_leaf_id + invocation_id.x;
+    var curr_id = tree[curr_leaf_id].parent;
+
+    // TODO: this only works if we could use strong memory ordering for the atomicAdd.
+    //       Otherwise there is no guarantee the counter isn’t incremented before the
+    //       updated aabb is written into `tree[curr_id].aabb`.
+    loop {
+        let refit_count = atomicAdd(&tree[curr_id].refit_count, 1u);
+
+        if refit_count == 0 {
+            // If `refit_count` was 0 then the other thread hasn’t reached this node
+            // yet and the sibbling aabb might not be available yet.
+            // Stop the propagation to the parents here, the other thread will do it.
+            break;
+        } else {
+            // If `refit_count` was 1 then the other thread has already reached this node
+            // and we know the sibblings aabb is available. So we can continue the propagation.
+
+            // TODO PERF: instead of re-reading both aabbs, we could keep the aabb from the
+            //            previous loop so we don’t have to re-fetch one of the two aabbs.
+            let left = tree[tree[curr_id].left].aabb;
+            let right = tree[tree[curr_id].right].aabb;
+            tree[curr_id].aabb = Aabb::merge(left, right);
+
+            if curr_id == 0 {
+                // We reached the root, can’t go higher.
+                break;
+            }
+
+            curr_id = tree[curr_id].parent;
+            // workgroupBarrier();
+        }
+    }
+}
+
+@compute @workgroup_size(WORKGROUP_SIZE, 1, 1)
+fn refit(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
+    // TODO PERF: we could use shared memory atomics between threads belonging to the same
+    //            workgroup.
+    // Bottom-up refit. Leaf index starts at `num_colliders`.
+    let num_threads = num_workgroups.x * WORKGROUP_SIZE * num_workgroups.y * num_workgroups.z;
+    let first_leaf_id = num_colliders - 1;
+
+    for (var i = invocation_id.x; i < num_colliders; i += num_threads) {
+        let curr_leaf_id = first_leaf_id + i;
+        let leaf_collider = sorted_colliders[i];
+        let leaf_pose = poses[leaf_collider];
+        let leaf_shape = shapes[leaf_collider];
+
+        tree[curr_leaf_id].aabb = Aabb::from_shape(leaf_pose, leaf_shape);
+        tree[curr_leaf_id].left = leaf_collider;
+
+        // Propagate to ancestors.
+        var curr_id = tree[curr_leaf_id].parent;
+
+        loop {
+            let refit_count = atomicAdd(&tree[curr_id].refit_count, 1u);
+
+            if refit_count == 0 {
+                // If `refit_count` was 0 then the other thread hasn’t reached this node
+                // yet and the sibbling aabb might not be available yet.
+                // Stop the propagation to the parents here, the other thread will do it.
+                break;
+            }
+
+            // If `refit_count` was 1 then the other thread has already reached this node
+            // and we know the sibblings aabb is available. So we can continue the propagation.
+
+            // TODO PERF: instead of re-reading both aabbs, we could keep the aabb from the
+            //            previous loop so we don’t have to re-fetch one of the two aabbs.
+            let left = tree[tree[curr_id].left].aabb;
+            let right = tree[tree[curr_id].right].aabb;
+            tree[curr_id].aabb = Aabb::merge(left, right);
+
+            if curr_id == 0 {
+                // We reached the root, can’t go higher.
+                break;
+            }
+
+            curr_id = tree[curr_id].parent;
+        }
+    }
+}
+
+@compute @workgroup_size(WORKGROUP_SIZE, 1, 1)
+fn find_collision_pairs(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
+    let num_threads = num_workgroups.x * WORKGROUP_SIZE * num_workgroups.y * num_workgroups.z;
+    let first_leaf_id = num_colliders - 1u;
+
+    for (var leaf_i = invocation_id.x; leaf_i < num_colliders; leaf_i += num_threads) {
+        let i = tree[first_leaf_id + leaf_i].left;
+        var aabb1 = tree[first_leaf_id + leaf_i].aabb;
+        let prediction = 2.0e-3; // TODO: should be configurable.
+        let dilation = Vector(prediction);
+        aabb1.mins -= dilation;
+        aabb1.maxs += dilation;
+
+        // Traverse the tree.
+        var curr_id = 0u;
+        var stack = array<u32, 64>();
+        var stack_len = 1u;
+        stack[0u] = 0u;
+
+        while stack_len != 0 {
+            stack_len -= 1u;
+            let curr_id = stack[stack_len];
+            let node = &tree[curr_id];
+
+            if curr_id >= first_leaf_id {
+                // We reached a leaf, register a collision pair.
+                let j = (*node).left;
+                // NOTE: we don’t have to compare i < j to avoid duplicates since that comparison already happened
+                //       alongside the AABB check.
+                let target_pair_index = atomicAdd(&collision_pairs_len, 1u);
+
+                // NOTE: if the index is out-of-bounds (meaning the `collision_pairs` isn’t
+                //       big enough), don’t write. But keep traversing so we get the exact count we need
+                //       for reallocating the buffers.
+                if target_pair_index < arrayLength(&collision_pairs) {
+                    collision_pairs[target_pair_index] = vec2(i, j);
+                }
+            } else {
+                let left = (*node).left;
+                let right = (*node).right;
+
+                // Go on the child only if the AABB intersects and either the child isn’t a leaf, or it is a leaf with associated collider
+                // smaller than `i` (to avoid duplicate pairs).
+                if (left < first_leaf_id || i < tree[left].left) && Aabb::check_intersection(aabb1, tree[left].aabb) {
+                    stack[stack_len] = (*node).left;
+                    stack_len += 1u;
+                }
+
+                // NOTE: on leaves (including tree[right]), the collider id is stored as the left child index.
+                if (right < first_leaf_id || i < tree[right].left) && Aabb::check_intersection(aabb1, tree[right].aabb) {
+                    stack[stack_len] = (*node).right;
+                    stack_len += 1u;
+                }
+            }
+        }
+    }
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn reset_collision_pairs() {
+    collision_pairs_len = 0u;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn init_indirect_args() {
+    collision_pairs_len_indirect_args = Indirect::DispatchIndirectArgs(Indirect::div_ceil(collision_pairs_len, WORKGROUP_SIZE), 1, 1);
+}
+
+#if DIM == 2
+// TODO: in 2D we could allocate 16 bits per dimension instead of 10.
+
+// Expands a 10-bit integer into 30 bits
+// by inserting 2 zeros after each bit.
+fn expandBits(v: u32) -> u32
+{
+    var vv = (v * 0x00010001u) & 0xFF0000FFu;
+    vv = (vv * 0x00000101u) & 0x0F00F00Fu;
+    vv = (vv * 0x00000011u) & 0xC30C30C3u;
+    vv = (vv * 0x00000005u) & 0x49249249u;
+    return vv;
+}
+
+// Calculates a 20-bit Morton code for the
+// given 2D point located within the unit cube [0,1].
+// TODO: this was ported 1-1 form the 3D version. We should adjust it
+//       so it uses 32 bits (16 + 16) in 2D.
+fn morton(v: vec2<f32>) -> u32
+{
+    let scaled_x = min(max(v.x * 1024.0f, 0.0f), 1023.0f);
+    let scaled_y = min(max(v.y * 1024.0f, 0.0f), 1023.0f);
+    let xx = expandBits(u32(scaled_x));
+    let yy = expandBits(u32(scaled_y));
+    return xx * 4 + yy * 2;
+}
+#else
+// Expands a 10-bit integer into 30 bits
+// by inserting 2 zeros after each bit.
+fn expandBits(v: u32) -> u32
+{
+    var vv = (v * 0x00010001u) & 0xFF0000FFu;
+    vv = (vv * 0x00000101u) & 0x0F00F00Fu;
+    vv = (vv * 0x00000011u) & 0xC30C30C3u;
+    vv = (vv * 0x00000005u) & 0x49249249u;
+    return vv;
+}
+
+// Calculates a 30-bit Morton code for the
+// given 3D point located within the unit cube [0,1].
+fn morton(v: vec3<f32>) -> u32
+{
+    let scaled_x = min(max(v.x * 1024.0f, 0.0f), 1023.0f);
+    let scaled_y = min(max(v.y * 1024.0f, 0.0f), 1023.0f);
+    let scaled_z = min(max(v.z * 1024.0f, 0.0f), 1023.0f);
+    let xx = expandBits(u32(scaled_x));
+    let yy = expandBits(u32(scaled_y));
+    let zz = expandBits(u32(scaled_z));
+    return xx * 4 + yy * 2 + zz;
+}
+#endif
+
+fn div_ceil(x: i32, y: i32) -> i32 {
+    return (x + y - 1) / y;
+}

--- a/crates/wgparry/src/broad_phase/mod.rs
+++ b/crates/wgparry/src/broad_phase/mod.rs
@@ -1,0 +1,32 @@
+//! Broad-phase collision detection algorithms for identifying potentially colliding pairs.
+//!
+//! Broad-phase collision detection quickly filters out non-colliding object pairs before
+//! running expensive narrow-phase tests. This module provides GPU-accelerated implementations
+//! of various broad-phase algorithms.
+//!
+//! # Available Algorithms
+//!
+//! ## Brute Force
+//!
+//! Tests all pairs of objects (O(n²) complexity). Simple but only practical for small scenes
+//! (typically < 100 objects). It is mostly relevant for testing and debugging.
+//!
+//! **Pros**: Simple, no preprocessing, deterministic.
+//! **Cons**: O(n²) scaling, impractical for large scenes.
+//!
+//! ## LBVH - Linear Bounding Volume Hierarchy
+//!
+//! Builds a binary tree of bounding volumes using Morton codes for spatial sorting.
+//! Near-linear construction time (O(n log n)) and efficient traversal make it suitable
+//! for large dynamic scenes.
+//!
+//! **Pros**: O(n log n) construction and O(log n) traversal (average), good for dynamic scenes.
+//! **Cons**: Requires tree rebuild for moving objects, more complex than brute force.
+
+mod brute_force_broad_phase;
+mod lbvh;
+mod narrow_phase;
+
+pub use brute_force_broad_phase::*;
+pub use lbvh::*;
+pub use narrow_phase::*;

--- a/crates/wgparry/src/utils/radix_sort/init_indirect_dispatches.wgsl
+++ b/crates/wgparry/src/utils/radix_sort/init_indirect_dispatches.wgsl
@@ -1,0 +1,33 @@
+//! Radix Sort Indirect Dispatch Initialization
+//!
+//! This single-threaded kernel computes the workgroup counts for the radix sort pipeline.
+//! It calculates how many workgroups are needed for the main sort passes and for the
+//! reduction passes based on the input size.
+//!
+//! Outputs:
+//! - num_wgs: Workgroups for main sort kernels (count, scatter)
+//! - num_reduce_wgs: Workgroups for reduction kernels (reduce, scan, scan_add)
+//!
+//! Called once at the beginning of each sort operation to set up indirect dispatches.
+
+#import wgparry::utils::sorting as sorting;
+
+@group(0) @binding(0) var<storage, read> len: u32;
+@group(0) @binding(1) var<storage, read_write> num_wgs: array<u32>;
+@group(0) @binding(2) var<storage, read_write> num_reduce_wgs: array<u32>;
+
+@compute
+@workgroup_size(1, 1, 1)
+fn main(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
+    if invocation_id.x != 0 {
+        return;
+    }
+
+    let wgs = sorting::div_ceil(len, sorting::BLOCK_SIZE);
+    num_wgs[0] = wgs;
+    num_wgs[1] = 1;
+    num_wgs[2] = 1;
+    num_reduce_wgs[0] = sorting::div_ceil(wgs, sorting::BLOCK_SIZE) * sorting::BIN_COUNT;
+    num_reduce_wgs[1] = 1;
+    num_reduce_wgs[2] = 1;
+}

--- a/crates/wgparry/src/utils/radix_sort/mod.rs
+++ b/crates/wgparry/src/utils/radix_sort/mod.rs
@@ -1,0 +1,477 @@
+//! Radix sort implementation, ported from `brush-sort`: <https://github.com/ArthurBrussee/brush/tree/main/crates/brush-sort>
+
+use naga_oil::compose::ComposerError;
+use wgcore::kernel::KernelDispatch;
+use wgcore::tensor::{GpuScalar, GpuVector};
+use wgcore::Shader;
+use wgpu::{BufferUsages, ComputePass, ComputePipeline, Device};
+
+// NOTE: must match the values from `sorting.wgsl`.
+const WG: u32 = 256;
+const ELEMENTS_PER_THREAD: u32 = 4;
+const BLOCK_SIZE: u32 = WG * ELEMENTS_PER_THREAD;
+#[allow(dead_code)]
+const BITS_PER_PASS: u32 = 4;
+#[allow(dead_code)]
+const BIN_COUNT: u32 = 1 << BITS_PER_PASS;
+
+#[derive(Shader)]
+#[shader(
+    derive(Sorting),
+    src = "./init_indirect_dispatches.wgsl",
+    composable = false
+)]
+struct InitIndirectDispatches {
+    main: ComputePipeline,
+}
+
+#[derive(Shader)]
+#[shader(derive(Sorting), src = "./sort_count.wgsl", composable = false)]
+struct SortCount {
+    main: ComputePipeline,
+}
+
+#[derive(Shader)]
+#[shader(derive(Sorting), src = "./sort_reduce.wgsl", composable = false)]
+struct SortReduce {
+    main: ComputePipeline,
+}
+
+#[derive(Shader)]
+#[shader(derive(Sorting), src = "./sort_scan.wgsl", composable = false)]
+struct SortScan {
+    main: ComputePipeline,
+}
+
+#[derive(Shader)]
+#[shader(derive(Sorting), src = "./sort_scan_add.wgsl", composable = false)]
+struct SortScanAdd {
+    main: ComputePipeline,
+}
+
+#[derive(Shader)]
+#[shader(derive(Sorting), src = "./sort_scatter.wgsl", composable = false)]
+struct SortScatter {
+    main: ComputePipeline,
+}
+
+#[derive(Shader)]
+#[shader(src = "./sorting.wgsl")]
+struct Sorting;
+
+/// GPU-accelerated radix sort for sorting large arrays of u32 keys with associated values.
+///
+/// This implementation uses a 4-bit radix (16 bins per pass) and processes multiple passes
+/// to sort up to 32-bit integers. The algorithm is highly optimized for GPU execution with:
+/// - Workgroup-local histograms for reduced memory bandwidth
+/// - Prefix sum (scan) operations for determining output positions
+/// - Scatter phase that writes sorted elements to output buffers
+///
+/// # Algorithm Overview
+///
+/// For each 4-bit pass (up to 8 passes for 32-bit keys):
+/// 1. **Count**: Histogram computation per workgroup
+/// 2. **Reduce**: Aggregate histograms across workgroups
+/// 3. **Scan**: Prefix sum on aggregated histograms
+/// 4. **Scan Add**: Distribute prefix sums back to workgroup histograms
+/// 5. **Scatter**: Write elements to sorted positions based on histograms
+///
+/// # Performance
+///
+/// - Processes ~10-100M elements/second on modern GPUs
+/// - Near-linear scaling with input size
+/// - Memory bandwidth bound (optimal for GPU)
+pub struct RadixSort {
+    init: InitIndirectDispatches,
+    count: SortCount,
+    reduce: SortReduce,
+    scan: SortScan,
+    scan_add: SortScanAdd,
+    scatter: SortScatter,
+}
+
+/// Workspace buffers for radix sort operations.
+///
+/// Maintains intermediate buffers needed by the radix sort algorithm:
+/// - Histogram buffers for bin counts
+/// - Reduction buffers for prefix sums
+/// - Ping-pong buffers for multi-pass sorting
+///
+/// The workspace is reusable across multiple sort operations and automatically
+/// resizes buffers as needed.
+pub struct RadixSortWorkspace {
+    pass_uniforms: Vec<GpuScalar<u32>>,
+    reduced_buf: GpuVector<u32>, // Tensor of size BLOCK_SIZE
+    count_buf: GpuVector<u32>,
+    num_wgs: GpuScalar<[u32; 3]>,
+    num_reduce_wgs: GpuScalar<[u32; 3]>,
+    output_keys_pong: GpuVector<u32>, // dual-buffering for output keys.
+    output_values_pong: GpuVector<u32>, // dual-buffering for output values.
+}
+
+impl RadixSortWorkspace {
+    /// Creates a new radix sort workspace with default buffer sizes.
+    ///
+    /// Buffers will be automatically resized on first use to match input data size.
+    ///
+    /// # Parameters
+    ///
+    /// - `device`: The GPU device to allocate buffers on
+    pub fn new(device: &Device) -> Self {
+        let zeros = vec![0u32; BLOCK_SIZE as usize];
+        Self {
+            pass_uniforms: vec![],
+            reduced_buf: GpuVector::init(device, &zeros, BufferUsages::STORAGE),
+            count_buf: GpuVector::uninit(device, 0, BufferUsages::STORAGE),
+            num_wgs: GpuScalar::init(
+                device,
+                [1; 3],
+                BufferUsages::STORAGE | BufferUsages::INDIRECT,
+            ),
+            num_reduce_wgs: GpuScalar::init(
+                device,
+                [1; 3],
+                BufferUsages::STORAGE | BufferUsages::INDIRECT,
+            ),
+            output_keys_pong: GpuVector::uninit(device, 0, BufferUsages::STORAGE),
+            output_values_pong: GpuVector::uninit(device, 0, BufferUsages::STORAGE),
+        }
+    }
+}
+
+impl RadixSort {
+    /// Creates a new radix sort instance by compiling shaders on the given device.
+    ///
+    /// # Parameters
+    ///
+    /// - `device`: The GPU device to compile shaders for
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(RadixSort)` on successful shader compilation
+    /// - `Err(ComposerError)` if shader compilation fails
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of the radix sort shader stages fail to compile.
+    pub fn from_device(device: &Device) -> Result<Self, ComposerError> {
+        Ok(Self {
+            init: InitIndirectDispatches::from_device(device)?,
+            count: SortCount::from_device(device)?,
+            reduce: SortReduce::from_device(device)?,
+            scan: SortScan::from_device(device)?,
+            scan_add: SortScanAdd::from_device(device)?,
+            scatter: SortScatter::from_device(device)?,
+        })
+    }
+
+    /// Dispatches the radix sort operation to sort keys with associated values.
+    ///
+    /// The sort is stable: elements with equal keys maintain their relative order.
+    /// Both keys and values are sorted together, making this useful for indirect sorting
+    /// (where values are indices into another array).
+    ///
+    /// # Parameters
+    ///
+    /// - `device`: The GPU device
+    /// - `pass`: The compute pass to record commands into
+    /// - `workspace`: Workspace buffers (automatically resized if needed)
+    /// - `input_keys`: The u32 keys to sort
+    /// - `input_values`: Associated values to sort alongside keys
+    /// - `n_sort`: Number of elements to sort (must be <= input buffer size)
+    /// - `sorting_bits`: Number of bits to sort (1-32). Use 32 for full sorting,
+    ///   or fewer bits if your keys have a limited range (e.g., 24 for Morton codes)
+    /// - `output_keys`: Buffer to write sorted keys to
+    /// - `output_values`: Buffer to write sorted values to
+    ///
+    /// # Panics
+    ///
+    /// - Panics if `input_keys` and `input_values` have different lengths
+    /// - Panics if `sorting_bits > 32`
+    ///
+    /// # Performance Tips
+    ///
+    /// - Use the minimum `sorting_bits` needed for your data range
+    /// - Reuse the same `workspace` across multiple sort operations
+    /// - Ensure input buffers are properly aligned for GPU access
+    pub fn dispatch(
+        &self,
+        device: &Device,
+        pass: &mut ComputePass,
+        workspace: &mut RadixSortWorkspace,
+        input_keys: &GpuVector<u32>,
+        input_values: &GpuVector<u32>,
+        n_sort: &GpuScalar<u32>,
+        sorting_bits: u32,
+        output_keys: &GpuVector<u32>,
+        output_values: &GpuVector<u32>,
+    ) {
+        assert_eq!(
+            input_keys.len(),
+            input_values.len(),
+            "Input keys and values must have the same number of elements"
+        );
+        assert!(sorting_bits <= 32, "Can only sort up to 32 bits");
+
+        let max_n = input_keys.len() as u32;
+
+        // compute buffer and dispatch sizes
+        let max_needed_wgs = max_n.div_ceil(BLOCK_SIZE);
+        if workspace.count_buf.len() < max_needed_wgs as u64 * 16 {
+            workspace.count_buf =
+                GpuVector::uninit(device, max_needed_wgs * 16, BufferUsages::STORAGE);
+        }
+
+        KernelDispatch::new(device, pass, &self.init.main)
+            .bind0([
+                n_sort.buffer(),
+                workspace.num_wgs.buffer(),
+                workspace.num_reduce_wgs.buffer(),
+            ])
+            .dispatch(1);
+
+        let mut cur_keys = input_keys;
+        let mut cur_vals = input_values;
+
+        if workspace.output_keys_pong.len() < input_keys.len() {
+            // TODO: is this OK even in the case where we call the radix sort multiple times
+            //       successively but with increasing input buffer sizes? Wondering if that could
+            //       free the previous buffer and then crash the previous invocation.
+            workspace.output_keys_pong =
+                GpuVector::uninit(device, input_keys.len() as u32, BufferUsages::STORAGE);
+            workspace.output_values_pong =
+                GpuVector::uninit(device, input_values.len() as u32, BufferUsages::STORAGE);
+        }
+
+        let num_passes = sorting_bits.div_ceil(4);
+        let mut output_keys = output_keys;
+        let mut output_values = output_values;
+        let mut output_keys_pong = &workspace.output_keys_pong;
+        let mut output_values_pong = &workspace.output_values_pong;
+
+        if num_passes.is_multiple_of(2) {
+            // Make sure the last pass has the user provided `output_keys`
+            // set as the output buffer so that the final results doesn’t end
+            // up stored in the workspace’s pong buffers instead.
+            std::mem::swap(&mut output_keys, &mut output_keys_pong);
+            std::mem::swap(&mut output_values, &mut output_values_pong);
+        }
+
+        for pass_id in 0..num_passes {
+            if pass_id as usize >= workspace.pass_uniforms.len() {
+                workspace.pass_uniforms.push(GpuScalar::init(
+                    device,
+                    pass_id * 4,
+                    BufferUsages::STORAGE | BufferUsages::UNIFORM,
+                ));
+            }
+
+            let uniforms_buffer = &workspace.pass_uniforms[pass_id as usize];
+
+            KernelDispatch::new(device, pass, &self.count.main)
+                .bind0([
+                    uniforms_buffer.buffer(),
+                    n_sort.buffer(),
+                    cur_keys.buffer(),
+                    workspace.count_buf.buffer(),
+                ])
+                .dispatch_indirect(workspace.num_wgs.buffer());
+
+            KernelDispatch::new(device, pass, &self.reduce.main)
+                .bind0([
+                    n_sort.buffer(),
+                    workspace.count_buf.buffer(),
+                    workspace.reduced_buf.buffer(),
+                ])
+                .dispatch_indirect(workspace.num_reduce_wgs.buffer());
+
+            KernelDispatch::new(device, pass, &self.scan.main)
+                .bind0([n_sort.buffer(), workspace.reduced_buf.buffer()])
+                .dispatch(1);
+
+            KernelDispatch::new(device, pass, &self.scan_add.main)
+                .bind0([
+                    n_sort.buffer(),
+                    workspace.reduced_buf.buffer(),
+                    workspace.count_buf.buffer(),
+                ])
+                .dispatch_indirect(workspace.num_reduce_wgs.buffer());
+
+            KernelDispatch::new(device, pass, &self.scatter.main)
+                .bind0([
+                    uniforms_buffer.buffer(),
+                    n_sort.buffer(),
+                    cur_keys.buffer(),
+                    cur_vals.buffer(),
+                    workspace.count_buf.buffer(),
+                    output_keys.buffer(),
+                    output_values.buffer(),
+                ])
+                .dispatch_indirect(workspace.num_wgs.buffer());
+
+            if pass_id == 0 {
+                cur_keys = output_keys;
+                cur_vals = output_values;
+                output_keys = output_keys_pong;
+                output_values = output_values_pong;
+            } else {
+                std::mem::swap(&mut cur_keys, &mut output_keys);
+                std::mem::swap(&mut cur_vals, &mut output_values);
+            }
+        }
+    }
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use crate::utils::radix_sort::RadixSortWorkspace;
+    use crate::utils::RadixSort;
+    use na::DVector;
+    use wgcore::gpu::GpuInstance;
+    use wgcore::kernel::CommandEncoderExt;
+    use wgcore::tensor::{GpuScalar, GpuVector};
+    use wgpu::BufferUsages;
+
+    pub fn cpu_argsort<T: Ord>(data: &[T]) -> Vec<usize> {
+        let mut indices = (0..data.len()).collect::<Vec<_>>();
+        indices.sort_by_key(|&i| &data[i]);
+        indices
+    }
+
+    #[futures_test::test]
+    #[serial_test::serial]
+    async fn test_sorting() {
+        let gpu = GpuInstance::new().await.unwrap();
+        let sort = RadixSort::from_device(gpu.device()).unwrap();
+        let mut workspace = RadixSortWorkspace::new(gpu.device());
+
+        for i in 0u32..128 {
+            let keys_inp = [
+                5 + i * 4,
+                i,
+                6,
+                123,
+                74657,
+                123,
+                999,
+                2u32.pow(24) + 123,
+                6,
+                7,
+                8,
+                0,
+                i * 2,
+                16 + i,
+                128 * i,
+            ];
+
+            let values_inp: Vec<_> = keys_inp.iter().copied().map(|x| x * 2 + 5).collect();
+
+            let input_usages = BufferUsages::STORAGE;
+            let output_usages = BufferUsages::STORAGE | BufferUsages::COPY_SRC;
+            let staging_usage = BufferUsages::MAP_READ | BufferUsages::COPY_DST;
+
+            let keys = GpuVector::init(gpu.device(), &keys_inp, input_usages);
+            let values = GpuVector::init(gpu.device(), &values_inp, input_usages);
+            let out_keys = GpuVector::init(gpu.device(), &keys_inp, output_usages);
+            let out_values = GpuVector::init(gpu.device(), &values_inp, output_usages);
+            let staging_keys = GpuVector::init(gpu.device(), &keys_inp, staging_usage);
+            let staging_values = GpuVector::init(gpu.device(), &values_inp, staging_usage);
+            let num_points =
+                GpuScalar::init(gpu.device(), keys_inp.len() as u32, BufferUsages::STORAGE);
+
+            let mut encoder = gpu.device().create_command_encoder(&Default::default());
+            let mut pass = encoder.compute_pass("test", None);
+            sort.dispatch(
+                gpu.device(),
+                &mut pass,
+                &mut workspace,
+                &keys,
+                &values,
+                &num_points,
+                32,
+                &out_keys,
+                &out_values,
+            );
+            drop(pass);
+            staging_keys.copy_from(&mut encoder, &out_keys);
+            staging_values.copy_from(&mut encoder, &out_values);
+            gpu.queue().submit(Some(encoder.finish()));
+
+            let result_keys = staging_keys.read(gpu.device()).await.unwrap();
+            let result_values = staging_values.read(gpu.device()).await.unwrap();
+
+            let inds = cpu_argsort(&keys_inp);
+            let ref_keys: Vec<u32> = inds.iter().map(|&i| keys_inp[i]).collect();
+            let ref_values: Vec<u32> = inds.iter().map(|&i| values_inp[i]).collect();
+
+            assert_eq!(DVector::from(ref_keys), DVector::from(result_keys));
+            assert_eq!(DVector::from(ref_values), DVector::from(result_values));
+        }
+    }
+
+    #[futures_test::test]
+    #[serial_test::serial]
+    async fn test_sorting_big() {
+        use rand::Rng;
+
+        let gpu = GpuInstance::new().await.unwrap();
+        let sort = RadixSort::from_device(gpu.device()).unwrap();
+        let mut workspace = RadixSortWorkspace::new(gpu.device());
+
+        // Simulate some data as one might find for a bunch of gaussians.
+        let mut rng = rand::rng();
+        let mut keys_inp = Vec::new();
+        for i in 0..10000 {
+            let start = rng.random_range(i..i + 150);
+            let end = rng.random_range(start..start + 250);
+
+            for j in start..end {
+                if rng.random::<f32>() < 0.5 {
+                    keys_inp.push(j);
+                }
+            }
+        }
+        let values_inp: Vec<_> = keys_inp.iter().map(|&x| x * 2 + 5).collect();
+
+        let input_usages = BufferUsages::STORAGE;
+        let output_usages = BufferUsages::STORAGE | BufferUsages::COPY_SRC;
+        let staging_usage = BufferUsages::MAP_READ | BufferUsages::COPY_DST;
+
+        let keys = GpuVector::init(gpu.device(), &keys_inp, input_usages);
+        let values = GpuVector::init(gpu.device(), &values_inp, input_usages);
+        let out_keys = GpuVector::init(gpu.device(), &keys_inp, output_usages);
+        let out_values = GpuVector::init(gpu.device(), &values_inp, output_usages);
+        let staging_keys = GpuVector::init(gpu.device(), &keys_inp, staging_usage);
+        let staging_values = GpuVector::init(gpu.device(), &values_inp, staging_usage);
+        let num_points =
+            GpuScalar::init(gpu.device(), keys_inp.len() as u32, BufferUsages::STORAGE);
+
+        let mut encoder = gpu.device().create_command_encoder(&Default::default());
+        let mut pass = encoder.compute_pass("test", None);
+        sort.dispatch(
+            gpu.device(),
+            &mut pass,
+            &mut workspace,
+            &keys,
+            &values,
+            &num_points,
+            32,
+            &out_keys,
+            &out_values,
+        );
+        drop(pass);
+        staging_keys.copy_from(&mut encoder, &out_keys);
+        staging_values.copy_from(&mut encoder, &out_values);
+        gpu.queue().submit(Some(encoder.finish()));
+
+        let result_keys = staging_keys.read(gpu.device()).await.unwrap();
+        let result_values = staging_values.read(gpu.device()).await.unwrap();
+
+        let inds = cpu_argsort(&keys_inp);
+        let ref_keys: Vec<u32> = inds.iter().map(|&i| keys_inp[i]).collect();
+        let ref_values: Vec<u32> = inds.iter().map(|&i| values_inp[i]).collect();
+
+        assert_eq!(DVector::from(ref_keys), DVector::from(result_keys));
+        assert_eq!(DVector::from(ref_values), DVector::from(result_values));
+    }
+}

--- a/crates/wgparry/src/utils/radix_sort/sort_count.wgsl
+++ b/crates/wgparry/src/utils/radix_sort/sort_count.wgsl
@@ -1,0 +1,73 @@
+//! Radix Sort Count (Histogram) Kernel
+//!
+//! First pass of radix sort: computes per-workgroup histograms for the current 4-bit digit.
+//!
+//! Algorithm:
+//! 1. Each workgroup processes BLOCK_SIZE (1024) consecutive elements
+//! 2. Initialize shared memory histogram to zeros
+//! 3. Each thread processes ELEMENTS_PER_THREAD (4) elements
+//! 4. Extract 4-bit key from current shift position
+//! 5. Atomically increment corresponding histogram bin
+//! 6. Write per-workgroup histogram to global memory
+//!
+//! Output layout: counts[bin * num_workgroups + workgroup_id]
+//! This produces num_workgroups separate histograms, one per workgroup.
+//!
+//! Workgroup size: 256 threads
+//! Shared memory: 16 atomic counters (one per bin)
+
+#import wgparry::utils::sorting as sorting;
+
+struct Uniforms {
+    /// Bit shift amount for this sort pass (0, 4, 8, 12, ..., 28).
+    shift: u32,
+}
+
+@group(0) @binding(0) var<storage, read> config: Uniforms;
+@group(0) @binding(1) var<storage, read> num_keys_arr: array<u32>;
+@group(0) @binding(2) var<storage, read> src: array<u32>;
+@group(0) @binding(3) var<storage, read_write> counts: array<u32>;
+
+/// Shared memory histogram for atomic accumulation.
+var<workgroup> histogram: array<atomic<u32>, sorting::BIN_COUNT>;
+
+@compute
+@workgroup_size(sorting::WG, 1, 1)
+fn main(
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+    @builtin(workgroup_id) gid: vec3<u32>,
+) {
+    let num_keys = num_keys_arr[0];
+
+    // let num_keys = num_keys_arr[0];
+    let num_wgs = sorting::div_ceil(num_keys, sorting::BLOCK_SIZE);
+    let group_id = gid.x;
+
+    if group_id >= num_wgs {
+        return;
+    }
+
+    if local_id.x < sorting::BIN_COUNT {
+        histogram[local_id.x] = 0u;
+    }
+    workgroupBarrier();
+
+    let wg_block_start = sorting::BLOCK_SIZE * group_id;
+    var block_index = wg_block_start + local_id.x;
+    let shift_bit = config.shift;
+    var data_index = block_index;
+
+    for (var i = 0u; i < sorting::ELEMENTS_PER_THREAD; i++) {
+        if data_index < num_keys {
+            let local_key = (src[data_index] >> shift_bit) & 0xfu;
+            atomicAdd(&histogram[local_key], 1u);
+        }
+        data_index += sorting::WG;
+    }
+    block_index += sorting::BLOCK_SIZE;
+    workgroupBarrier();
+    if local_id.x < sorting::BIN_COUNT {
+        let num_wgs = sorting::div_ceil(num_keys, sorting::BLOCK_SIZE);
+        counts[local_id.x * num_wgs + group_id] = histogram[local_id.x];
+    }
+}

--- a/crates/wgparry/src/utils/radix_sort/sort_reduce.wgsl
+++ b/crates/wgparry/src/utils/radix_sort/sort_reduce.wgsl
@@ -1,0 +1,49 @@
+#import wgparry::utils::sorting as sorting;
+
+@group(0) @binding(0) var<storage, read> num_keys_arr: array<u32>;
+@group(0) @binding(1) var<storage, read> counts: array<u32>;
+@group(0) @binding(2) var<storage, read_write> reduced: array<u32>;
+
+var<workgroup> sums: array<u32, sorting::WG>;
+
+@compute
+@workgroup_size(sorting::WG, 1, 1)
+fn main(
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+    @builtin(workgroup_id) gid: vec3<u32>,
+) {
+    let num_keys = num_keys_arr[0];
+    // let num_keys = num_keys_arr[0];
+    let num_wgs = sorting::div_ceil(num_keys, sorting::BLOCK_SIZE);
+    let num_reduce_wgs = sorting::BIN_COUNT * sorting::div_ceil(num_wgs, sorting::BLOCK_SIZE);
+
+    let group_id = gid.x;
+
+    if group_id >= num_reduce_wgs {
+        return;
+    }
+
+    let num_reduce_wg_per_bin = num_reduce_wgs / sorting::BIN_COUNT;
+    let bin_id = group_id / num_reduce_wg_per_bin;
+
+    let bin_offset = bin_id * num_wgs;
+    let base_index = (group_id % num_reduce_wg_per_bin) * sorting::BLOCK_SIZE;
+    var sum = 0u;
+    for (var i = 0u; i < sorting::ELEMENTS_PER_THREAD; i++) {
+        let data_index = base_index + i * sorting::WG + local_id.x;
+        if data_index < num_wgs {
+            sum += counts[bin_offset + data_index];
+        }
+    }
+    sums[local_id.x] = sum;
+    for (var i = 0u; i < 8u; i++) {
+        workgroupBarrier();
+        if local_id.x < ((sorting::WG / 2u) >> i) {
+            sum += sums[local_id.x + ((sorting::WG / 2u) >> i)];
+            sums[local_id.x] = sum;
+        }
+    }
+    if local_id.x == 0u {
+        reduced[group_id] = sum;
+    }
+}

--- a/crates/wgparry/src/utils/radix_sort/sort_scan.wgsl
+++ b/crates/wgparry/src/utils/radix_sort/sort_scan.wgsl
@@ -1,0 +1,61 @@
+#import wgparry::utils::sorting as sorting;
+
+@group(0) @binding(0) var<storage, read> num_keys_arr: array<u32>;
+@group(0) @binding(1) var<storage, read_write> reduced: array<u32>;
+
+var<workgroup> sums: array<u32, sorting::WG>;
+var<workgroup> lds: array<array<u32, sorting::WG>, sorting::ELEMENTS_PER_THREAD>;
+
+@compute
+@workgroup_size(sorting::WG, 1, 1)
+fn main(
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+    @builtin(workgroup_id) group_id: vec3<u32>,
+) {
+    let num_keys = num_keys_arr[0];
+    // let num_keys = num_keys_arr[0];
+    let num_wgs = sorting::div_ceil(num_keys, sorting::BLOCK_SIZE);
+    let num_reduce_wgs = sorting::BIN_COUNT * sorting::div_ceil(num_wgs, sorting::BLOCK_SIZE);
+
+    for (var i = 0u; i < sorting::ELEMENTS_PER_THREAD; i++) {
+        let data_index = i * sorting::WG + local_id.x;
+        let col = (i * sorting::WG + local_id.x) / sorting::ELEMENTS_PER_THREAD;
+        let row = (i * sorting::WG + local_id.x) % sorting::ELEMENTS_PER_THREAD;
+        lds[row][col] = reduced[data_index];
+    }
+    workgroupBarrier();
+    var sum = 0u;
+    for (var i = 0u; i < sorting::ELEMENTS_PER_THREAD; i++) {
+        let tmp = lds[i][local_id.x];
+        lds[i][local_id.x] = sum;
+        sum += tmp;
+    }
+    // workgroup prefix sum
+    sums[local_id.x] = sum;
+    for (var i = 0u; i < 8u; i++) {
+        workgroupBarrier();
+        if local_id.x >= (1u << i) {
+            sum += sums[local_id.x - (1u << i)];
+        }
+        workgroupBarrier();
+        sums[local_id.x] = sum;
+    }
+    workgroupBarrier();
+    sum = 0u;
+    if local_id.x > 0u {
+        sum = sums[local_id.x - 1u];
+    }
+    for (var i = 0u; i < sorting::ELEMENTS_PER_THREAD; i++) {
+        lds[i][local_id.x] += sum;
+    }
+    // lds now contains exclusive prefix sum
+    workgroupBarrier();
+    for (var i = 0u; i < sorting::ELEMENTS_PER_THREAD; i++) {
+        let data_index = i * sorting::WG + local_id.x;
+        let col = (i * sorting::WG + local_id.x) / sorting::ELEMENTS_PER_THREAD;
+        let row = (i * sorting::WG + local_id.x) % sorting::ELEMENTS_PER_THREAD;
+        if data_index < num_reduce_wgs {
+            reduced[data_index] = lds[row][col];
+        }
+    }
+}

--- a/crates/wgparry/src/utils/radix_sort/sort_scan_add.wgsl
+++ b/crates/wgparry/src/utils/radix_sort/sort_scan_add.wgsl
@@ -1,0 +1,76 @@
+#import wgparry::utils::sorting as sorting;
+
+@group(0) @binding(0) var<storage, read> num_keys_arr: array<u32>;
+@group(0) @binding(1) var<storage, read> reduced: array<u32>;
+@group(0) @binding(2) var<storage, read_write> counts: array<u32>;
+
+var<workgroup> sums: array<u32, sorting::WG>;
+var<workgroup> lds: array<array<u32, sorting::WG>, sorting::ELEMENTS_PER_THREAD>;
+
+@compute
+@workgroup_size(sorting::WG, 1, 1)
+fn main(
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+    @builtin(workgroup_id) gid: vec3<u32>,
+) {
+    let num_keys = num_keys_arr[0];
+    // let num_keys = num_keys_arr[0];
+    let num_wgs = sorting::div_ceil(num_keys, sorting::BLOCK_SIZE);
+    let num_reduce_wgs = sorting::BIN_COUNT * sorting::div_ceil(num_wgs, sorting::BLOCK_SIZE);
+
+    let group_id = gid.x;
+
+    if group_id >= num_reduce_wgs {
+        return;
+    }
+
+    let num_reduce_wg_per_bin = num_reduce_wgs / sorting::BIN_COUNT;
+
+    let bin_id = group_id / num_reduce_wg_per_bin;
+    let bin_offset = bin_id * num_wgs;
+    let base_index = (group_id % num_reduce_wg_per_bin) * sorting::ELEMENTS_PER_THREAD * sorting::WG;
+
+    for (var i = 0u; i < sorting::ELEMENTS_PER_THREAD; i++) {
+        let data_index = base_index + i * sorting::WG + local_id.x;
+        let col = (i * sorting::WG + local_id.x) / sorting::ELEMENTS_PER_THREAD;
+        let row = (i * sorting::WG + local_id.x) % sorting::ELEMENTS_PER_THREAD;
+        // This is not gated, we let robustness do it for us
+        lds[row][col] = counts[bin_offset + data_index];
+    }
+    workgroupBarrier();
+    var sum = 0u;
+    for (var i = 0u; i < sorting::ELEMENTS_PER_THREAD; i++) {
+        let tmp = lds[i][local_id.x];
+        lds[i][local_id.x] = sum;
+        sum += tmp;
+    }
+    // workgroup prefix sum
+    sums[local_id.x] = sum;
+    for (var i = 0u; i < 8u; i++) {
+        workgroupBarrier();
+        if local_id.x >= (1u << i) {
+            sum += sums[local_id.x - (1u << i)];
+        }
+        workgroupBarrier();
+        sums[local_id.x] = sum;
+    }
+    workgroupBarrier();
+    sum = reduced[group_id];
+    if local_id.x > 0u {
+        sum += sums[local_id.x - 1u];
+    }
+    for (var i = 0u; i < sorting::ELEMENTS_PER_THREAD; i++) {
+        lds[i][local_id.x] += sum;
+    }
+    // lds now contains exclusive prefix sum
+    // Note: storing inclusive might be slightly cheaper here
+    workgroupBarrier();
+    for (var i = 0u; i < sorting::ELEMENTS_PER_THREAD; i++) {
+        let data_index = base_index + i * sorting::WG + local_id.x;
+        let col = (i * sorting::WG + local_id.x) / sorting::ELEMENTS_PER_THREAD;
+        let row = (i * sorting::WG + local_id.x) % sorting::ELEMENTS_PER_THREAD;
+        if data_index < num_wgs {
+            counts[bin_offset + data_index] = lds[row][col];
+        }
+    }
+}

--- a/crates/wgparry/src/utils/radix_sort/sort_scatter.wgsl
+++ b/crates/wgparry/src/utils/radix_sort/sort_scatter.wgsl
@@ -1,0 +1,151 @@
+//! Radix Sort Scatter Kernel
+//!
+//! Final pass of radix sort: scatters keys and values to their sorted positions.
+//!
+//! Algorithm:
+//! 1. Load global histogram offsets for this workgroup
+//! 2. For each element batch (ELEMENTS_PER_THREAD iterations):
+//!    a. Hierarchically sort elements within workgroup using 2 passes of 2-bit sorts
+//!    b. Use shared memory for local rearrangement
+//!    c. Compute local histogram for this batch
+//!    d. Determine global output position: global_offset + local_offset
+//!    e. Write sorted key and value to output buffers
+//!    f. Update global offsets for next iteration
+//!
+//! Hierarchical sorting:
+//! - First sorts by bits [shift+0:shift+2]
+//! - Then sorts by bits [shift+2:shift+4]
+//! - Uses shared memory prefix sums for efficient local sorting
+//!
+//! Workgroup size: 256 threads
+//! Shared memory: Scratch arrays + histogram cache + local histogram
+
+#import wgparry::utils::sorting as sorting;
+
+struct Uniforms {
+    /// Bit shift amount for this sort pass.
+    shift: u32,
+}
+
+@group(0) @binding(0) var<storage, read> config: Uniforms;
+@group(0) @binding(1) var<storage, read> num_keys_arr: array<u32>;
+@group(0) @binding(2) var<storage, read> src: array<u32>;
+@group(0) @binding(3) var<storage, read> values: array<u32>;
+@group(0) @binding(4) var<storage, read> counts: array<u32>;
+@group(0) @binding(5) var<storage, read_write> out: array<u32>;
+@group(0) @binding(6) var<storage, read_write> out_values: array<u32>;
+
+var<workgroup> lds_sums: array<u32, sorting::WG>;
+var<workgroup> lds_scratch: array<u32, sorting::WG>;
+var<workgroup> bin_offset_cache: array<u32, sorting::WG>;
+var<workgroup> local_histogram: array<atomic<u32>, sorting::BIN_COUNT>;
+
+@compute
+@workgroup_size(sorting::WG, 1, 1)
+fn main(
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+    @builtin(workgroup_id) gid: vec3<u32>,
+) {
+    let num_keys = num_keys_arr[0];
+    // let num_keys = num_keys_arr[0];
+    let num_wgs = sorting::div_ceil(num_keys, sorting::BLOCK_SIZE);
+
+    let group_id = gid.x;
+
+    if group_id >= num_wgs {
+        return;
+    }
+
+    if local_id.x < sorting::BIN_COUNT {
+        bin_offset_cache[local_id.x] = counts[local_id.x * num_wgs + group_id];
+    }
+    workgroupBarrier();
+    let wg_block_start = sorting::BLOCK_SIZE * group_id;
+    let block_index = wg_block_start + local_id.x;
+    var data_index = block_index;
+    for (var i = 0u; i < sorting::ELEMENTS_PER_THREAD; i++) {
+        if local_id.x < sorting::BIN_COUNT {
+            local_histogram[local_id.x] = 0u;
+        }
+        var local_key = ~0u;
+        var local_value = 0u;
+
+        if data_index < num_keys {
+            local_key = src[data_index];
+            local_value = values[data_index];
+        }
+
+        for (var bit_shift = 0u; bit_shift < sorting::BITS_PER_PASS; bit_shift += 2u) {
+            let key_index = (local_key >> config.shift) & 0xfu;
+            let bit_key = (key_index >> bit_shift) & 3u;
+            var packed_histogram = 1u << (bit_key * 8u);
+            // workgroup prefix sum
+            var sum = packed_histogram;
+            lds_scratch[local_id.x] = sum;
+            for (var i = 0u; i < 8u; i++) {
+                workgroupBarrier();
+                if local_id.x >= (1u << i) {
+                    sum += lds_scratch[local_id.x - (1u << i)];
+                }
+                workgroupBarrier();
+                lds_scratch[local_id.x] = sum;
+            }
+            workgroupBarrier();
+            packed_histogram = lds_scratch[sorting::WG - 1u];
+            packed_histogram = (packed_histogram << 8u) + (packed_histogram << 16u) + (packed_histogram << 24u);
+            var local_sum = packed_histogram;
+            if local_id.x > 0u {
+                local_sum += lds_scratch[local_id.x - 1u];
+            }
+            let key_offset = (local_sum >> (bit_key * 8u)) & 0xffu;
+            
+            lds_sums[key_offset] = local_key;
+            workgroupBarrier();
+            local_key = lds_sums[local_id.x];
+            workgroupBarrier();
+        
+            lds_sums[key_offset] = local_value;
+            workgroupBarrier();
+            local_value = lds_sums[local_id.x];
+            workgroupBarrier();
+        }
+        let key_index = (local_key >> config.shift) & 0xfu;
+        atomicAdd(&local_histogram[key_index], 1u);
+        workgroupBarrier();
+        var histogram_local_sum = 0u;
+        if local_id.x < sorting::BIN_COUNT {
+            histogram_local_sum = local_histogram[local_id.x];
+        }
+        // workgroup prefix sum of histogram
+        var histogram_prefix_sum = histogram_local_sum;
+        if local_id.x < sorting::BIN_COUNT {
+            lds_scratch[local_id.x] = histogram_prefix_sum;
+        }
+        for (var i = 0u; i < 4u; i++) {
+            workgroupBarrier();
+            if local_id.x >= (1u << i) && local_id.x < sorting::BIN_COUNT {
+                histogram_prefix_sum += lds_scratch[local_id.x - (1u << i)];
+            }
+            workgroupBarrier();
+            if local_id.x < sorting::BIN_COUNT {
+                lds_scratch[local_id.x] = histogram_prefix_sum;
+            }
+        }
+        let global_offset = bin_offset_cache[key_index];
+        workgroupBarrier();
+        var local_offset = local_id.x;
+        if key_index > 0u {
+            local_offset -= lds_scratch[key_index - 1u];
+        }
+        let total_offset = global_offset + local_offset;
+        if total_offset < num_keys {
+            out[total_offset] = local_key;
+            out_values[total_offset] = local_value;
+        }
+        if local_id.x < sorting::BIN_COUNT {
+            bin_offset_cache[local_id.x] += local_histogram[local_id.x];
+        }
+        workgroupBarrier();
+        data_index += sorting::WG;
+    }
+}

--- a/crates/wgparry/src/utils/radix_sort/sorting.wgsl
+++ b/crates/wgparry/src/utils/radix_sort/sorting.wgsl
@@ -1,0 +1,45 @@
+//! GPU Radix Sort - Common Constants and Utilities
+//!
+//! This module defines shared constants for the GPU radix sort implementation.
+//! The sort processes 32-bit keys in multiple passes, handling 4 bits per pass
+//! using 16 histogram bins.
+//!
+//! Radix sort overview:
+//! - Processes 32-bit keys in 8 passes (4 bits per pass)
+//! - Each pass sorts into 16 bins (2^4)
+//! - Stable sort (preserves relative order of equal keys)
+//! - Sorts both keys and associated values
+//!
+//! Workgroup configuration:
+//! - 256 threads per workgroup
+//! - 4 elements per thread
+//! - 1024 elements per workgroup (BLOCK_SIZE)
+//!
+//! Performance: O(k*n) where k=8 passes, linear in practice
+//! Memory: O(n) for keys/values + O(workgroups * 16) for histograms
+//!
+//! Mostly copied from [brush](https://github.com/ArthurBrussee/brush)
+//! (Apache-2.0 license).
+
+#define_import_path wgparry::utils::sorting
+
+const OFFSET: u32 = 42;
+/// Workgroup size (threads per workgroup).
+const WG: u32 = 256;
+
+/// Number of bits processed per radix sort pass.
+const BITS_PER_PASS: u32 = 4;
+/// Number of histogram bins (2^BITS_PER_PASS).
+const BIN_COUNT: u32 = 1u << BITS_PER_PASS;
+/// Total histogram size across all threads in a workgroup.
+const HISTOGRAM_SIZE: u32 = WG * BIN_COUNT;
+/// Number of elements each thread processes.
+const ELEMENTS_PER_THREAD: u32 = 4;
+
+/// Total elements processed by one workgroup.
+const BLOCK_SIZE = WG * ELEMENTS_PER_THREAD;
+
+/// Integer division with ceiling (rounds up).
+fn div_ceil(a: u32, b: u32) -> u32 {
+    return (a + b - 1u) / b;
+}


### PR DESCRIPTION
I recommend looking at individual commits.

- Implement a O(n²) broad-phase algorithm.
- Implement a BVH-based broad-phase algorithm, including LBVH construction and traversal. This is based on the paper [Maximizing Parallelism in the Construction of BVHs, Octrees, and k-d Trees](https://research.nvidia.com/sites/default/files/publications/karras2012hpg_paper.pdf).
- Port radix-sort from [brush](https://github.com/ArthurBrussee/brush) (Apache v2 license). This is needed by the LBVH implementation.

Note that this PR is part of a chain of PRs converging towards a fully functional GPU rigid-body physics prototype. The CI will not succeed until the [last PR](https://github.com/wgmath/wgmath/pull/10).