### PR TITLE
feat: add support for impulse-based joints

### DIFF
--- a/crates/wgcore/src/gpu.rs
+++ b/crates/wgcore/src/gpu.rs
@@ -39,8 +39,8 @@ impl GpuInstance {
                 label: None,
                 required_features: wgpu::Features::TIMESTAMP_QUERY,
                 required_limits: wgpu::Limits {
-                    max_buffer_size: 1_000_000_000,
-                    max_storage_buffer_binding_size: 1_000_000_000,
+                    max_buffer_size: 600_000_000,
+                    max_storage_buffer_binding_size: 600_000_000,
                     ..Default::default()
                 },
                 memory_hints: Default::default(),

--- a/crates/wgebra/src/geometry/rot2.rs
+++ b/crates/wgebra/src/geometry/rot2.rs
@@ -1,7 +1,8 @@
+use crate::utils::WgTrig;
 use wgcore::Shader;
 
 #[derive(Shader)]
-#[shader(src = "rot2.wgsl")]
+#[shader(derive(WgTrig), src = "rot2.wgsl")]
 /// Shader exposing a 2D rotation type and operations.
 pub struct WgRot2;
 

--- a/crates/wgebra/src/geometry/rot2.wgsl
+++ b/crates/wgebra/src/geometry/rot2.wgsl
@@ -1,5 +1,7 @@
 #define_import_path wgebra::rot2
 
+#import wgebra::trig as Trig
+
 
 /// Compact representation of a 2D rotation.
 struct Rot2 {
@@ -43,6 +45,11 @@ fn toMatrix(r: Rot2) -> mat2x2<f32> {
         vec2(r.cos_sin.x, r.cos_sin.y),
         vec2(-r.cos_sin.y, r.cos_sin.x)
     );
+}
+
+/// The rotation angle (in radians).
+fn angle(r: Rot2) -> f32 {
+    return Trig::stable_atan2(r.cos_sin.y, r.cos_sin.x);
 }
 
 /// The inverse of a 2d rotation.

--- a/crates/wgrapier/crates/examples2d/all_examples2.rs
+++ b/crates/wgrapier/crates/examples2d/all_examples2.rs
@@ -6,6 +6,9 @@ use wgrapier_testbed2d::{SimulationState, Testbed};
 mod balls2;
 mod boxes2;
 mod boxes_and_balls2;
+mod joint_ball2;
+mod joint_fixed2;
+mod joint_prismatic2;
 mod pyramid2;
 
 fn demo_name_from_command_line() -> Option<String> {
@@ -40,6 +43,9 @@ pub async fn main() {
         ("Boxes", boxes2::init_world),
         ("Boxes & balls", boxes_and_balls2::init_world),
         ("Pyramid", pyramid2::init_world),
+        ("Joints (spherical)", joint_ball2::init_world),
+        ("Joints (prismatic)", joint_prismatic2::init_world),
+        ("Joints (fixed)", joint_fixed2::init_world),
     ];
 
     // Lexicographic sort, with stress tests moved at the end of the list.

--- a/crates/wgrapier/crates/examples2d/joint_ball2.rs
+++ b/crates/wgrapier/crates/examples2d/joint_ball2.rs
@@ -1,0 +1,68 @@
+use rapier2d::prelude::*;
+use wgrapier_testbed2d::SimulationState;
+
+pub fn init_world() -> SimulationState {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let mut impulse_joints = ImpulseJointSet::new();
+
+    /*
+     * Create the balls
+     */
+    // Build the rigid body.
+    let rad = 0.4;
+    let numi = 350; // Num vertical nodes.
+    let numk = 350; // Num horizontal nodes.
+    let shift = 1.0;
+
+    let mut body_handles = Vec::new();
+
+    for k in 0..numk {
+        for i in 0..numi {
+            let fk = k as f32;
+            let fi = i as f32;
+
+            let status = if i == 0 && (k < numk / 5 || k >= (4 * numk) / 5) {
+                RigidBodyType::Fixed
+            } else {
+                RigidBodyType::Dynamic
+            };
+
+            let rigid_body =
+                RigidBodyBuilder::new(status).translation(vector![fk * shift, -fi * shift]);
+            let child_handle = bodies.insert(rigid_body);
+            let collider = ColliderBuilder::ball(rad);
+            colliders.insert_with_parent(collider, child_handle, &mut bodies);
+
+            // Vertical joint.
+            if i > 0 {
+                let parent_handle = *body_handles.last().unwrap();
+                let joint = RevoluteJointBuilder::new().local_anchor2(point![0.0, shift]);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
+            }
+
+            // Horizontal joint.
+            if k > 0 {
+                let parent_index = body_handles.len() - numi;
+                let parent_handle = body_handles[parent_index];
+                let joint = RevoluteJointBuilder::new().local_anchor2(point![-shift, 0.0]);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
+            }
+
+            body_handles.push(child_handle);
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    SimulationState {
+        bodies,
+        colliders,
+        impulse_joints,
+    }
+    // testbed.look_at(point![numk as f32 * rad, numi as f32 * -rad], 5.0);
+}

--- a/crates/wgrapier/crates/examples2d/joint_fixed2.rs
+++ b/crates/wgrapier/crates/examples2d/joint_fixed2.rs
@@ -1,0 +1,77 @@
+use rapier2d::prelude::*;
+use wgrapier_testbed2d::SimulationState;
+
+pub fn init_world() -> SimulationState {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let mut impulse_joints = ImpulseJointSet::new();
+
+    /*
+     * Create the balls
+     */
+    // Build the rigid body.
+    let rad = 0.4;
+    let num = 50; // Num vertical nodes.
+    let shift = 1.0;
+
+    let mut body_handles = Vec::new();
+
+    for xx in 0..8 {
+        let x = xx as f32 * shift * (num as f32 + 2.0);
+
+        for yy in 0..8 {
+            let y = yy as f32 * shift * (num as f32 + 4.0);
+
+            for k in 0..num {
+                for i in 0..num {
+                    let fk = k as f32;
+                    let fi = i as f32;
+
+                    let status = if k == 0 {
+                        RigidBodyType::Fixed
+                    } else {
+                        RigidBodyType::Dynamic
+                    };
+
+                    let rigid_body = RigidBodyBuilder::new(status)
+                        .translation(vector![x + fk * shift, y - fi * shift]);
+                    let child_handle = bodies.insert(rigid_body);
+                    let collider = ColliderBuilder::ball(rad);
+                    colliders.insert_with_parent(collider, child_handle, &mut bodies);
+
+                    // Vertical joint.
+                    if i > 0 {
+                        let parent_handle = *body_handles.last().unwrap();
+                        let joint = FixedJointBuilder::new()
+                            .local_frame2(Isometry::translation(0.0, shift));
+                        impulse_joints.insert(parent_handle, child_handle, joint, true);
+                    }
+
+                    // Horizontal joint.
+                    if k > 0 {
+                        let parent_index = body_handles.len() - num;
+                        let parent_handle = body_handles[parent_index];
+                        let joint = FixedJointBuilder::new()
+                            .local_frame2(Isometry::translation(-shift, 0.0));
+                        impulse_joints.insert(parent_handle, child_handle, joint, true);
+                    }
+
+                    body_handles.push(child_handle);
+                }
+            }
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    SimulationState {
+        bodies,
+        colliders,
+        impulse_joints,
+    }
+    // testbed.look_at(point![50.0, 50.0], 5.0);
+}

--- a/crates/wgrapier/crates/examples2d/joint_prismatic2.rs
+++ b/crates/wgrapier/crates/examples2d/joint_prismatic2.rs
@@ -1,0 +1,64 @@
+use rapier2d::prelude::*;
+use wgrapier_testbed2d::SimulationState;
+
+pub fn init_world() -> SimulationState {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let mut impulse_joints = ImpulseJointSet::new();
+
+    /*
+     * Create the balls
+     */
+    // Build the rigid body.
+    let rad = 0.4;
+    let num = 10;
+    let shift = 1.0;
+
+    for l in 0..38 {
+        let y = l as f32 * shift * (num as f32 + 2.0) * 2.0;
+
+        for j in 0..300 {
+            let x = j as f32 * shift * 4.0;
+
+            let ground = RigidBodyBuilder::fixed().translation(vector![x, y]);
+            let mut curr_parent = bodies.insert(ground);
+            let collider = ColliderBuilder::cuboid(rad, rad);
+            colliders.insert_with_parent(collider, curr_parent, &mut bodies);
+
+            for i in 0..num {
+                let y = y - (i + 1) as f32 * shift;
+                let density = 1.0;
+                let rigid_body = RigidBodyBuilder::dynamic().translation(vector![x, y]);
+                let curr_child = bodies.insert(rigid_body);
+                let collider = ColliderBuilder::cuboid(rad, rad).density(density);
+                colliders.insert_with_parent(collider, curr_child, &mut bodies);
+
+                let axis = if i % 2 == 0 {
+                    UnitVector::new_normalize(vector![1.0, 1.0])
+                } else {
+                    UnitVector::new_normalize(vector![-1.0, 1.0])
+                };
+
+                let prism = PrismaticJointBuilder::new(axis)
+                    .local_anchor2(point![0.0, shift])
+                    .limits([-1.5, 1.5]);
+                impulse_joints.insert(curr_parent, curr_child, prism, true);
+
+                curr_parent = curr_child;
+            }
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    SimulationState {
+        bodies,
+        colliders,
+        impulse_joints,
+    }
+    // testbed.look_at(point![80.0, 80.0], 15.0);
+}

--- a/crates/wgrapier/crates/examples3d/all_examples3.rs
+++ b/crates/wgrapier/crates/examples3d/all_examples3.rs
@@ -8,6 +8,10 @@ use wgrapier_testbed3d::{SimulationState, Testbed};
 mod balls3;
 mod boxes3;
 mod boxes_and_balls3;
+mod joint_ball3;
+mod joint_fixed3;
+mod joint_prismatic3;
+mod joint_revolute3;
 mod keva3;
 mod many_pyramids3;
 mod pyramid3;
@@ -41,6 +45,10 @@ pub fn demo_builders() -> Vec<(&'static str, fn() -> SimulationState)> {
         ("Pyramid", pyramid3::init_world),
         ("Many pyramids", many_pyramids3::init_world),
         ("Keva tower", keva3::init_world),
+        ("Joints (Spherical)", joint_ball3::init_world),
+        ("Joints (Fixed)", joint_fixed3::init_world),
+        ("Joints (Prismatic)", joint_prismatic3::init_world),
+        ("Joints (Revolute)", joint_revolute3::init_world),
     ];
 
     // Lexicographic sort, with stress tests moved at the end of the list.

--- a/crates/wgrapier/crates/examples3d/joint_ball3.rs
+++ b/crates/wgrapier/crates/examples3d/joint_ball3.rs
@@ -1,0 +1,93 @@
+use rapier3d::prelude::*;
+use wgrapier_testbed3d::SimulationState;
+
+pub fn init_world() -> SimulationState {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let mut impulse_joints = ImpulseJointSet::new();
+
+    let rad = 0.4;
+    let ni = 200;
+    let nk = 301;
+    let shift = 1.0;
+    let center = vector![nk as f32 * shift / 2.0, 0.0, ni as f32 * shift / 2.0];
+
+    let mut body_handles = Vec::new();
+
+    // A lot of joints. Kind of like a piece of cloth.
+    for k in 0..nk {
+        for i in 0..ni {
+            let fk = k as f32;
+            let fi = i as f32;
+
+            let status = if ((i == 0 || i == ni - 1) && (k % 4 == 0 || k == ni - 1))
+                || ((k == 0 || k == nk - 1) && (i % 4 == 0 || i == nk - 1))
+            {
+                RigidBodyType::Fixed
+            } else {
+                RigidBodyType::Dynamic
+            };
+
+            let rigid_body = RigidBodyBuilder::new(status)
+                .translation(vector![fk * shift, 0.0, fi * shift] - center);
+            let child_handle = bodies.insert(rigid_body);
+            let collider = if status == RigidBodyType::Fixed {
+                ColliderBuilder::cuboid(rad, rad, rad)
+            } else {
+                ColliderBuilder::ball(rad)
+            };
+            colliders.insert_with_parent(collider, child_handle, &mut bodies);
+
+            // Vertical joint.
+            if i > 0 {
+                let parent_handle = *body_handles.last().unwrap();
+                let joint = SphericalJointBuilder::new().local_anchor2(point![0.0, 0.0, -shift]);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
+            }
+
+            // Horizontal joint.
+            if k > 0 {
+                let parent_index = body_handles.len() - ni;
+                let parent_handle = body_handles[parent_index];
+                let joint = SphericalJointBuilder::new().local_anchor2(point![-shift, 0.0, 0.0]);
+                impulse_joints.insert(parent_handle, child_handle, joint, true);
+            }
+
+            body_handles.push(child_handle);
+        }
+    }
+
+    // Some rigid-bodies to fall on top.
+    let nj = 10;
+    let nk = nk / 3;
+    let ni = ni / 6;
+    let rad = rad * 2.5;
+
+    for k in 0..nk {
+        for i in 0..ni {
+            for j in 0..nj {
+                let body = RigidBodyBuilder::dynamic().translation(vector![
+                    (k as f32 - nk as f32 / 2.0) * rad * 2.1,
+                    j as f32 * rad * 2.1 + 2.0,
+                    (i as f32 - ni as f32 / 2.0) * rad * 2.1,
+                ]);
+                let handle = bodies.insert(body);
+                let collider = ColliderBuilder::cuboid(rad, rad, rad);
+                colliders.insert_with_parent(collider, handle, &mut bodies);
+            }
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    SimulationState {
+        bodies,
+        colliders,
+        impulse_joints,
+    }
+    // testbed.look_at(point![-110.0, -46.0, 170.0], point![54.0, -38.0, 29.0]);
+}

--- a/crates/wgrapier/crates/examples3d/joint_fixed3.rs
+++ b/crates/wgrapier/crates/examples3d/joint_fixed3.rs
@@ -1,0 +1,84 @@
+use rapier3d::prelude::*;
+use wgrapier_testbed3d::SimulationState;
+
+pub fn init_world() -> SimulationState {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let mut impulse_joints = ImpulseJointSet::new();
+
+    let rad = 0.4;
+    let num = 10;
+    let shift = 1.0;
+
+    let mut body_handles = Vec::new();
+
+    for m in 0..10 {
+        let z = m as f32 * shift * (num as f32 + 2.0);
+
+        for l in 0..10 {
+            let y = l as f32 * shift * 3.0;
+
+            for j in 0..10 {
+                let x = j as f32 * shift * (num as f32) * 2.0;
+
+                for k in 0..num {
+                    for i in 0..num {
+                        let fk = k as f32;
+                        let fi = i as f32;
+
+                        // NOTE: the num - 2 test is to avoid two consecutive
+                        // fixed bodies. Because physx will crash if we add
+                        // a joint between these.
+
+                        let status = if i == 0 && (k % 4 == 0 && k != num - 2 || k == num - 1) {
+                            RigidBodyType::Fixed
+                        } else {
+                            RigidBodyType::Dynamic
+                        };
+
+                        let rigid_body = RigidBodyBuilder::new(status).translation(vector![
+                            x + fk * shift,
+                            y,
+                            z + fi * shift
+                        ]);
+                        let child_handle = bodies.insert(rigid_body);
+                        let collider = ColliderBuilder::ball(rad);
+                        colliders.insert_with_parent(collider, child_handle, &mut bodies);
+
+                        // Vertical joint.
+                        if i > 0 {
+                            let parent_handle = *body_handles.last().unwrap();
+                            let joint =
+                                FixedJointBuilder::new().local_anchor2(point![0.0, 0.0, -shift]);
+                            impulse_joints.insert(parent_handle, child_handle, joint, true);
+                        }
+
+                        // Horizontal joint.
+                        if k > 0 {
+                            let parent_index = body_handles.len() - num;
+                            let parent_handle = body_handles[parent_index];
+                            let joint =
+                                FixedJointBuilder::new().local_anchor2(point![-shift, 0.0, 0.0]);
+                            impulse_joints.insert(parent_handle, child_handle, joint, true);
+                        }
+
+                        body_handles.push(child_handle);
+                    }
+                }
+            }
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    SimulationState {
+        bodies,
+        colliders,
+        impulse_joints,
+    }
+    // testbed.look_at(point![-38.0, 14.0, 108.0], point![46.0, 12.0, 23.0]);
+}

--- a/crates/wgrapier/crates/examples3d/joint_prismatic3.rs
+++ b/crates/wgrapier/crates/examples3d/joint_prismatic3.rs
@@ -1,0 +1,64 @@
+use rapier3d::prelude::*;
+use wgrapier_testbed3d::SimulationState;
+
+pub fn init_world() -> SimulationState {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let mut impulse_joints = ImpulseJointSet::new();
+
+    let rad = 0.4;
+    let num = 10;
+    let shift = 1.0;
+
+    for m in 0..20 {
+        let z = m as f32 * shift * (num as f32 + 2.0);
+
+        for l in 0..20 {
+            let y = l as f32 * shift * (num as f32) * 2.0;
+
+            for j in 0..30 {
+                let x = j as f32 * shift * 4.0;
+
+                let ground = RigidBodyBuilder::fixed().translation(vector![x, y, z]);
+                let mut curr_parent = bodies.insert(ground);
+                let collider = ColliderBuilder::cuboid(rad, rad, rad);
+                colliders.insert_with_parent(collider, curr_parent, &mut bodies);
+
+                for i in 0..num {
+                    let z = z + (i + 1) as f32 * shift;
+                    let density = 1.0;
+                    let rigid_body = RigidBodyBuilder::dynamic().translation(vector![x, y, z]);
+                    let curr_child = bodies.insert(rigid_body);
+                    let collider = ColliderBuilder::cuboid(rad, rad, rad).density(density);
+                    colliders.insert_with_parent(collider, curr_child, &mut bodies);
+
+                    let axis = if i % 2 == 0 {
+                        UnitVector::new_normalize(vector![1.0, 1.0, 0.0])
+                    } else {
+                        UnitVector::new_normalize(vector![-1.0, 1.0, 0.0])
+                    };
+
+                    let prism = PrismaticJointBuilder::new(axis)
+                        .local_anchor2(point![0.0, 0.0, -shift])
+                        .limits([-2.0, 0.0]);
+                    impulse_joints.insert(curr_parent, curr_child, prism, true);
+
+                    curr_parent = curr_child;
+                }
+            }
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    SimulationState {
+        bodies,
+        colliders,
+        impulse_joints,
+    }
+    // testbed.look_at(point![262.0, 63.0, 124.0], point![101.0, 4.0, -3.0]);
+}

--- a/crates/wgrapier/crates/examples3d/joint_revolute3.rs
+++ b/crates/wgrapier/crates/examples3d/joint_revolute3.rs
@@ -1,0 +1,81 @@
+use rapier3d::prelude::*;
+use wgrapier_testbed3d::SimulationState;
+
+pub fn init_world() -> SimulationState {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let mut impulse_joints = ImpulseJointSet::new();
+
+    let rad = 0.4;
+    let num = 10;
+    let shift = 2.0;
+    let nk = 10;
+    let nj = 50;
+
+    for k in 0..nk {
+        for l in 0..4 {
+            let y = l as f32 * shift * (num as f32) * 3.0;
+
+            for j in 0..nj {
+                let x = (j as f32 - nj as f32 / 2.0) * shift * 4.0;
+                let z = (k as f32 - nk as f32 / 2.0) * num as f32 * shift * 2.1;
+
+                let ground = RigidBodyBuilder::fixed().translation(vector![x, y, z]);
+                let mut curr_parent = bodies.insert(ground);
+                let collider = ColliderBuilder::cuboid(rad, rad, rad);
+                colliders.insert_with_parent(collider, curr_parent, &mut bodies);
+
+                for i in 0..num {
+                    // Create four bodies.
+                    let z = z + i as f32 * shift * 2.0 + shift;
+                    let positions = [
+                        Isometry::translation(x, y, z),
+                        Isometry::translation(x + shift, y, z),
+                        Isometry::translation(x + shift, y, z + shift),
+                        Isometry::translation(x, y, z + shift),
+                    ];
+
+                    let mut handles = [curr_parent; 4];
+                    for k in 0..4 {
+                        let density = 1.0;
+                        let rigid_body = RigidBodyBuilder::dynamic().pose(positions[k]);
+                        handles[k] = bodies.insert(rigid_body);
+                        let collider = ColliderBuilder::cuboid(rad, rad, rad).density(density);
+                        colliders.insert_with_parent(collider, handles[k], &mut bodies);
+                    }
+
+                    // Setup four impulse_joints.
+                    let x = Vector::x_axis();
+                    let z = Vector::z_axis();
+
+                    let revs = [
+                        RevoluteJointBuilder::new(z).local_anchor2(point![0.0, 0.0, -shift]),
+                        RevoluteJointBuilder::new(x).local_anchor2(point![-shift, 0.0, 0.0]),
+                        RevoluteJointBuilder::new(z).local_anchor2(point![0.0, 0.0, -shift]),
+                        RevoluteJointBuilder::new(x).local_anchor2(point![shift, 0.0, 0.0]),
+                    ];
+
+                    impulse_joints.insert(curr_parent, handles[0], revs[0], true);
+                    impulse_joints.insert(handles[0], handles[1], revs[1], true);
+                    impulse_joints.insert(handles[1], handles[2], revs[2], true);
+                    impulse_joints.insert(handles[2], handles[3], revs[3], true);
+
+                    curr_parent = handles[3];
+                }
+            }
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    SimulationState {
+        bodies,
+        colliders,
+        impulse_joints,
+    }
+    // testbed.look_at(point![478.0, 83.0, 228.0], point![134.0, 83.0, -116.0]);
+}

--- a/crates/wgrapier/src/dynamics/body.rs
+++ b/crates/wgrapier/src/dynamics/body.rs
@@ -51,12 +51,12 @@ pub struct GpuVelocity {
 pub struct GpuLocalMassProperties {
     /// Square root of inverse principal inertia (scalar in 2D).
     #[cfg(feature = "dim2")]
-    pub inv_principal_inertia_sqrt: f32,
+    pub inv_principal_inertia: f32,
     #[cfg(feature = "dim3")]
     inv_ref_frame: Vector4<f32>,
     /// Square root of inverse principal inertia tensor (3D vector in 3D).
     #[cfg(feature = "dim3")]
-    pub inv_principal_inertia_sqrt: nalgebra::Vector3<f32>,
+    pub inv_principal_inertia: nalgebra::Vector3<f32>,
     /// The inverse mass.
     pub inv_mass: Vector<f32>,
     /// The center-of-mass.
@@ -68,7 +68,7 @@ pub struct GpuLocalMassProperties {
 /// Rigid-body mass-properties, with a layout compatible with the corresponding WGSL struct.
 pub struct GpuWorldMassProperties {
     /// The inverse angular inertia tensor.
-    pub inv_inertia_sqrt: AngularInertia<f32>,
+    pub inv_inertia: AngularInertia<f32>,
     /// The inverse mass.
     pub inv_mass: Vector<f32>,
     /// The center-of-mass.
@@ -78,10 +78,7 @@ pub struct GpuWorldMassProperties {
 impl From<MassProperties> for GpuLocalMassProperties {
     fn from(props: MassProperties) -> Self {
         GpuLocalMassProperties {
-            #[cfg(feature = "dim2")]
-            inv_principal_inertia_sqrt: props.inv_principal_inertia.sqrt(),
-            #[cfg(feature = "dim3")]
-            inv_principal_inertia_sqrt: props.inv_principal_inertia.map(|e| e.sqrt()),
+            inv_principal_inertia: props.inv_principal_inertia,
             #[cfg(feature = "dim3")]
             inv_ref_frame: props.principal_inertia_local_frame.coords,
             inv_mass: Vector::repeat(props.inv_mass),
@@ -95,11 +92,11 @@ impl Default for GpuLocalMassProperties {
         GpuLocalMassProperties {
             #[rustfmt::skip]
             #[cfg(feature = "dim2")]
-            inv_principal_inertia_sqrt: 1.0,
+            inv_principal_inertia: 1.0,
             #[cfg(feature = "dim3")]
             inv_ref_frame: Vector4::w(),
             #[cfg(feature = "dim3")]
-            inv_principal_inertia_sqrt: Vector::repeat(1.0),
+            inv_principal_inertia: Vector::repeat(1.0),
             inv_mass: Vector::repeat(1.0),
             com: Vector::zeros(),
         }
@@ -111,9 +108,9 @@ impl Default for GpuWorldMassProperties {
         GpuWorldMassProperties {
             #[rustfmt::skip]
             #[cfg(feature = "dim2")]
-            inv_inertia_sqrt: 1.0,
+            inv_inertia: 1.0,
             #[cfg(feature = "dim3")]
-            inv_inertia_sqrt: AngularInertia::identity(),
+            inv_inertia: AngularInertia::identity(),
             inv_mass: Vector::repeat(1.0),
             com: Vector::zeros(),
         }

--- a/crates/wgrapier/src/dynamics/constraint.rs
+++ b/crates/wgrapier/src/dynamics/constraint.rs
@@ -114,9 +114,13 @@ pub struct GpuTwoBodyConstraintElement {
 #[derive(Copy, Clone, PartialEq, Debug, ShaderType)]
 pub struct GpuTwoBodyConstraintNormalPart {
     /// Angular Jacobian component for body A.
-    pub gcross_a: AngVector<f32>,
+    pub torque_dir_a: AngVector<f32>,
+    /// Angular Jacobian component for body A, multiplied by the inverse angular inertia.
+    pub ii_torque_dir_a: AngVector<f32>,
     /// Angular Jacobian component for body B.
-    pub gcross_b: AngVector<f32>,
+    pub torque_dir_b: AngVector<f32>,
+    /// Angular Jacobian component for body B, multiplied by the inverse angular inertia.
+    pub ii_torque_dir_b: AngVector<f32>,
     /// Right-hand side with bias term (used in stabilization phase).
     pub rhs: f32,
     /// Right-hand side without bias term (used in velocity solving phase).
@@ -137,9 +141,13 @@ pub struct GpuTwoBodyConstraintNormalPart {
 #[derive(Copy, Clone, PartialEq, Debug, ShaderType)]
 pub struct GpuTwoBodyConstraintTangentPart {
     /// Angular Jacobian components for body A (one or two directions).
-    pub gcross_a: [AngVector<f32>; SUB_LEN],
+    pub torque_dir_a: [AngVector<f32>; SUB_LEN],
+    /// Angular Jacobian components for body A (one or two directions) multiplied by the angular inertia tensor.
+    pub ii_torque_dir_a: [AngVector<f32>; SUB_LEN],
     /// Angular Jacobian components for body B (one or two directions).
-    pub gcross_b: [AngVector<f32>; SUB_LEN],
+    pub torque_dir_b: [AngVector<f32>; SUB_LEN],
+    /// Angular Jacobian components for body B (one or two directions) multiplied by the angular inertia tensor.
+    pub ii_torque_dir_b: [AngVector<f32>; SUB_LEN],
     /// Right-hand sides with bias terms.
     pub rhs: [f32; SUB_LEN],
     /// Right-hand sides without bias terms.

--- a/crates/wgrapier/src/dynamics/constraint.wgsl
+++ b/crates/wgrapier/src/dynamics/constraint.wgsl
@@ -129,10 +129,14 @@ struct TwoBodyConstraintElement {
 struct TwoBodyConstraintNormalPart {
     /// Angular contribution for body A: r_a × normal
     /// (In 2D: scalar cross product, in 3D: vector cross product)
-    gcross_a: AngVector,
+    torque_dir_a: AngVector,
+    /// `torque_dir_a` multiplied by the inverse angular inertia tensor.
+    ii_torque_dir_a: AngVector,
 
     /// Angular contribution for body B: r_b × normal
-    gcross_b: AngVector,
+    torque_dir_b: AngVector,
+    /// `torque_dir_b` multiplied by the inverse angular inertia tensor.
+    ii_torque_dir_b: AngVector,
 
     /// Right-hand side: target relative velocity (includes bias for correction).
     /// rhs = desired_velocity + bias_velocity
@@ -160,10 +164,14 @@ struct TwoBodyConstraintNormalPart {
 /// Solved as a bilateral constraint with limits.
 struct TwoBodyConstraintTangentPart {
     /// Angular contributions for body A (one per tangent direction).
-    gcross_a: array<AngVector, SUB_LEN>,
+    torque_dir_a: array<AngVector, SUB_LEN>,
+    /// `torque_dir_b` multiplied by the inverse angular inertia tensor.
+    ii_torque_dir_a: array<AngVector, SUB_LEN>,
 
     /// Angular contributions for body B (one per tangent direction).
-    gcross_b: array<AngVector, SUB_LEN>,
+    torque_dir_b: array<AngVector, SUB_LEN>,
+    /// `torque_dir_b` multiplied by the inverse angular inertia tensor.
+    ii_torque_dir_b: array<AngVector, SUB_LEN>,
 
     /// Right-hand sides (one per tangent direction).
     rhs: array<f32, SUB_LEN>,

--- a/crates/wgrapier/src/dynamics/joint.rs
+++ b/crates/wgrapier/src/dynamics/joint.rs
@@ -1,0 +1,464 @@
+use crate::dynamics::{
+    GpuLocalMassProperties, GpuSimParams, GpuVelocity, GpuWorldMassProperties, WgBody, WgSimParams,
+};
+use encase::ShaderType;
+use nalgebra::Vector2;
+use rapier::dynamics::{
+    GenericJoint, ImpulseJoint, ImpulseJointSet, JointLimits, JointMotor, RigidBodyHandle,
+};
+use rapier::math::SPATIAL_DIM;
+use rapier::prelude::MotorModel;
+use std::collections::HashMap;
+use wgcore::kernel::KernelDispatch;
+use wgcore::tensor::{GpuScalar, GpuVector};
+use wgcore::Shader;
+use wgebra::{WgQuat, WgRot2, WgSim2, WgSim3};
+use wgparry::math::{AngVector, GpuSim, Vector};
+use wgparry::{dim_shader_defs, substitute_aliases};
+use wgpu::{BufferUsages, ComputePass, ComputePipeline, Device};
+
+#[cfg(feature = "dim2")]
+use wgebra::GpuSim2;
+#[cfg(feature = "dim3")]
+use {
+    nalgebra::{Similarity3, Vector4},
+    wgebra::GpuSim3,
+};
+
+#[derive(Copy, Clone, Debug, ShaderType)]
+pub(crate) struct GpuImpulseJoint {
+    body_a: u32,
+    body_b: u32,
+    data: GpuGenericJoint,
+}
+
+impl GpuImpulseJoint {
+    pub fn from_rapier(joint: &ImpulseJoint, body_id: &HashMap<RigidBodyHandle, u32>) -> Self {
+        Self {
+            body_a: body_id[&joint.body1],
+            body_b: body_id[&joint.body2],
+            data: joint.data.into(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, ShaderType)]
+#[cfg(feature = "dim2")]
+struct EncasedGpuSim {
+    rotation: Vector2<f32>,
+    translation: Vector2<f32>,
+    scale: f32,
+}
+
+#[cfg(feature = "dim2")]
+impl From<GpuSim2> for EncasedGpuSim {
+    fn from(value: GpuSim2) -> Self {
+        Self {
+            rotation: [
+                value.similarity.isometry.rotation.re,
+                value.similarity.isometry.rotation.im,
+            ]
+            .into(),
+            translation: value.similarity.isometry.translation.vector,
+            scale: value.similarity.scaling(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, ShaderType)]
+#[cfg(feature = "dim3")]
+struct EncasedGpuSim {
+    rotation: Vector4<f32>,
+    translation_scale: Vector4<f32>,
+}
+
+#[cfg(feature = "dim3")]
+impl From<GpuSim3> for EncasedGpuSim {
+    fn from(value: GpuSim3) -> Self {
+        Self {
+            rotation: value.isometry.rotation.coords,
+            translation_scale: value.isometry.translation.vector.push(value.scaling()),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, ShaderType)]
+struct GpuJointConstraintBuilder {
+    body1: u32,
+    body2: u32,
+    joint_id: u32,
+    joint: GpuGenericJoint,
+    constraint_id: u32,
+}
+
+#[derive(Copy, Clone, Debug, ShaderType)]
+struct GpuGenericJoint {
+    local_frame_a: EncasedGpuSim,
+    local_frame_b: EncasedGpuSim,
+    locked_axes: u32,
+    limit_axes: u32,
+    motor_axes: u32,
+    coupled_axes: u32,
+    limits: [GpuJointLimits; SPATIAL_DIM],
+    motors: [GpuJointMotor; SPATIAL_DIM],
+}
+
+impl From<GenericJoint> for GpuGenericJoint {
+    fn from(value: GenericJoint) -> Self {
+        Self {
+            #[cfg(feature = "dim2")]
+            local_frame_a: GpuSim::from(value.local_frame1).into(),
+            #[cfg(feature = "dim2")]
+            local_frame_b: GpuSim::from(value.local_frame2).into(),
+            #[cfg(feature = "dim3")]
+            local_frame_a: Similarity3::from_isometry(value.local_frame1, 1.0).into(),
+            #[cfg(feature = "dim3")]
+            local_frame_b: Similarity3::from_isometry(value.local_frame2, 1.0).into(),
+            locked_axes: value.locked_axes.bits() as u32,
+            limit_axes: value.limit_axes.bits() as u32,
+            motor_axes: value.motor_axes.bits() as u32,
+            coupled_axes: value.coupled_axes.bits() as u32,
+            limits: value.limits.map(|e| e.into()),
+            motors: value.motors.map(|e| e.into()),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, ShaderType)]
+struct GpuJointLimits {
+    min: f32,
+    max: f32,
+    impulse: f32,
+}
+
+impl From<JointLimits<f32>> for GpuJointLimits {
+    fn from(value: JointLimits<f32>) -> Self {
+        Self {
+            min: value.min,
+            max: value.max,
+            impulse: value.impulse,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, ShaderType)]
+struct GpuJointMotor {
+    target_vel: f32,
+    target_pos: f32,
+    stiffness: f32,
+    damping: f32,
+    max_force: f32,
+    impulse: f32,
+    model: u32,
+}
+
+impl From<JointMotor> for GpuJointMotor {
+    fn from(value: JointMotor) -> Self {
+        Self {
+            target_vel: value.target_vel,
+            target_pos: value.target_pos,
+            stiffness: value.stiffness,
+            damping: value.damping,
+            max_force: value.max_force,
+            impulse: value.impulse,
+            model: match value.model {
+                MotorModel::AccelerationBased => 0,
+                MotorModel::ForceBased => 1,
+            },
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, ShaderType)]
+pub(crate) struct GpuJointConstraint {
+    solver_vel_a: u32,
+    solver_vel_b: u32,
+    im_a: Vector<f32>,
+    im_b: Vector<f32>,
+    elements: [GpuJointConstraintElement; SPATIAL_DIM],
+    len: u32,
+}
+
+#[derive(Copy, Clone, Debug, ShaderType)]
+struct GpuJointConstraintElement {
+    joint_id: u32,
+    impulse: f32,
+    impulse_bounds: Vector2<f32>,
+    lin_jac: Vector<f32>,
+    ang_jac_a: AngVector<f32>,
+    ang_jac_b: AngVector<f32>,
+    ii_ang_jac_a: AngVector<f32>,
+    ii_ang_jac_b: AngVector<f32>,
+    inv_lhs: f32,
+    rhs: f32,
+    rhs_wo_bias: f32,
+    cfm_gain: f32,
+    cfm_coeff: f32,
+}
+
+/// A set of impulse joints simulated on the GPU.
+pub struct GpuImpulseJointSet {
+    len: u32,
+    num_colors: u32,
+    max_color_group_len: u32,
+    num_joints: GpuScalar<u32>,
+    curr_color: GpuScalar<u32>,
+    color_groups: GpuVector<u32>,
+    joints: GpuVector<GpuImpulseJoint>,
+    builders: GpuVector<GpuJointConstraintBuilder>,
+    constraints: GpuVector<GpuJointConstraint>,
+}
+
+impl GpuImpulseJointSet {
+    /// Converts a set of Rapier joints to a set of GPU joints.
+    pub fn from_rapier(
+        device: &Device,
+        joints: &ImpulseJointSet,
+        body_ids: &HashMap<RigidBodyHandle, u32>,
+    ) -> Self {
+        let usage = BufferUsages::STORAGE;
+        let len = joints.len() as u32;
+        let max_body_id = body_ids.values().copied().max().unwrap_or_default();
+
+        // Convert joints.
+        let mut unsorted_gpu_joints = vec![];
+        for (_, joint) in joints.iter() {
+            unsorted_gpu_joints.push(GpuImpulseJoint::from_rapier(joint, body_ids));
+        }
+
+        /*
+         * Run a simple static greedy graph coloring, and group the joints.
+         */
+        let mut colors = vec![];
+        let mut body_masks = vec![0u128; max_body_id as usize + 1];
+
+        // Find colors.
+        for joint in &unsorted_gpu_joints {
+            // TODO: don’t take fixed bodies into account for the coloring.
+            let a = joint.body_a as usize;
+            let b = joint.body_b as usize;
+            let mask = body_masks[a] | body_masks[b];
+            let color = mask.trailing_ones();
+            colors.push(color);
+            body_masks[a] |= 1 << color;
+            body_masks[b] |= 1 << color;
+        }
+
+        let num_colors = colors
+            .iter()
+            .copied()
+            .max()
+            .map(|n| n + 1)
+            .unwrap_or_default();
+        let mut color_groups = vec![0u32; num_colors as usize];
+
+        // Count size of color groups.
+        for color in &colors {
+            color_groups[*color as usize] += 1;
+        }
+
+        let max_color_group_len = color_groups.iter().copied().max().unwrap_or_default();
+        // println!(
+        //     "Found {} colors. Max len: {}",
+        //     num_colors, max_color_group_len
+        // );
+
+        // Prefix sum.
+        for i in 0..color_groups.len().saturating_sub(1) {
+            color_groups[i + 1] += color_groups[i];
+        }
+
+        // Bucket sort.
+        let mut target = color_groups.clone();
+        target.insert(0, 0);
+        let mut sorted_gpu_joints = unsorted_gpu_joints.clone();
+
+        for (joint, color) in unsorted_gpu_joints.iter().zip(colors.iter()) {
+            sorted_gpu_joints[target[*color as usize] as usize] = *joint;
+            target[*color as usize] += 1;
+        }
+
+        Self {
+            len,
+            num_colors,
+            max_color_group_len,
+            num_joints: GpuScalar::init(device, len, usage | BufferUsages::UNIFORM),
+            curr_color: GpuScalar::init(device, 0, usage),
+            color_groups: GpuVector::init(device, &color_groups, usage),
+            joints: GpuVector::encase(device, &sorted_gpu_joints, usage),
+            builders: GpuVector::uninit_encased(device, len, usage),
+            constraints: GpuVector::uninit_encased(device, len, usage),
+        }
+    }
+
+    /// Is this set empty?
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// The number of joints in this set.
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+}
+
+#[derive(Shader)]
+#[shader(
+    derive(WgSim2, WgSim3),
+    src = "joint.wgsl",
+    src_fn = "substitute_aliases",
+    shader_defs = "dim_shader_defs"
+)]
+/// Shader definition of joints.
+pub struct WgJoint;
+
+#[derive(Shader)]
+#[shader(
+    derive(WgJoint),
+    src = "joint_constraint.wgsl",
+    src_fn = "substitute_aliases",
+    shader_defs = "dim_shader_defs"
+)]
+/// Shader definition of joint constraints.
+pub struct WgJointConstraint;
+
+#[derive(Shader)]
+#[shader(
+    derive(
+        WgJoint,
+        WgJointConstraint,
+        WgSimParams,
+        WgBody,
+        WgSim2,
+        WgSim3,
+        WgQuat,
+        WgRot2
+    ),
+    src = "joint_constraint_builder.wgsl",
+    src_fn = "substitute_aliases",
+    shader_defs = "dim_shader_defs"
+)]
+/// A solver responsible for initializing and solving impulse-based joint constraints.
+pub struct WgJointSolver {
+    init: ComputePipeline,
+    update: ComputePipeline,
+    solve: ComputePipeline,
+    remove_bias: ComputePipeline,
+    reset_color: ComputePipeline,
+    inc_color: ComputePipeline,
+}
+
+/// Arguments given to the joint solver.
+pub struct JointSolverArgs<'a> {
+    /// The simulation parameters.
+    pub sim_params: &'a GpuScalar<GpuSimParams>,
+    /// The set of joints to solve.
+    pub joints: &'a GpuImpulseJointSet,
+    /// The body solvers.
+    pub solver_vels: &'a GpuVector<GpuVelocity>,
+
+    /// Rigid body poses.
+    pub poses: &'a GpuVector<GpuSim>,
+    /// World-space mass properties.
+    pub mprops: &'a GpuVector<GpuWorldMassProperties>,
+    /// Local-space mass properties.
+    pub local_mprops: &'a GpuVector<GpuLocalMassProperties>,
+}
+
+impl WgJointSolver {
+    const WORKGROUP_SIZE: u32 = 64;
+
+    /// Generate joint constraints for this set of joint.
+    pub fn init(&self, device: &Device, pass: &mut ComputePass, args: &JointSolverArgs) {
+        KernelDispatch::new(device, pass, &self.init)
+            .bind_at(
+                0,
+                [
+                    (args.joints.num_joints.buffer(), 0),
+                    (args.joints.joints.buffer(), 1),
+                    (args.joints.builders.buffer(), 2),
+                    (args.joints.constraints.buffer(), 3),
+                ],
+            )
+            .bind_at(
+                1,
+                [(args.poses.buffer(), 1), (args.local_mprops.buffer(), 3)],
+            )
+            .dispatch(args.joints.len.div_ceil(Self::WORKGROUP_SIZE))
+    }
+
+    /// Updates the non-linear terms of the joint constraints.
+    pub fn update(&self, device: &Device, pass: &mut ComputePass, args: &JointSolverArgs) {
+        KernelDispatch::new(device, pass, &self.update)
+            .bind_at(
+                0,
+                [
+                    (args.joints.num_joints.buffer(), 0),
+                    (args.joints.builders.buffer(), 2),
+                    (args.joints.constraints.buffer(), 3),
+                ],
+            )
+            .bind_at(
+                1,
+                [
+                    (args.sim_params.buffer(), 0),
+                    (args.poses.buffer(), 1),
+                    (args.mprops.buffer(), 4),
+                ],
+            )
+            .dispatch(args.joints.len.div_ceil(Self::WORKGROUP_SIZE))
+    }
+
+    /// Apply a single Projected-Gauss-Seidel step for solving joints.
+    ///
+    /// This intended to be used in the inner-loop of the TGS solver.
+    pub fn solve(
+        &self,
+        device: &Device,
+        pass: &mut ComputePass,
+        args: &JointSolverArgs,
+        use_bias: bool,
+    ) {
+        if !use_bias {
+            KernelDispatch::new(device, pass, &self.remove_bias)
+                .bind_at(
+                    0,
+                    [
+                        (args.joints.num_joints.buffer(), 0),
+                        (args.joints.constraints.buffer(), 3),
+                    ],
+                )
+                .dispatch(args.joints.len.div_ceil(Self::WORKGROUP_SIZE))
+        }
+
+        KernelDispatch::new(device, pass, &self.reset_color)
+            .bind_at(0, [(args.joints.curr_color.buffer(), 4)])
+            .dispatch(1);
+        for _ in 0..args.joints.num_colors {
+            KernelDispatch::new(device, pass, &self.solve)
+                .bind_at(
+                    0,
+                    [
+                        (args.joints.constraints.buffer(), 3),
+                        (args.joints.curr_color.buffer(), 4),
+                        (args.joints.color_groups.buffer(), 5),
+                    ],
+                )
+                .bind_at(1, [(args.solver_vels.buffer(), 2)])
+                // TODO PERF: figure out a way to dispatch a number of threads that fits
+                //            more tightly the size of the current color.
+                .dispatch(
+                    args.joints
+                        .max_color_group_len
+                        .div_ceil(Self::WORKGROUP_SIZE),
+                );
+            KernelDispatch::new(device, pass, &self.inc_color)
+                .bind_at(0, [(args.joints.curr_color.buffer(), 4)])
+                .dispatch(1);
+        }
+    }
+}
+
+wgcore::test_shader_compilation!(WgJoint, wgcore, wgparry::dim_shader_defs());
+wgcore::test_shader_compilation!(WgJointConstraint, wgcore, wgparry::dim_shader_defs());
+wgcore::test_shader_compilation!(WgJointSolver, wgcore, wgparry::dim_shader_defs());

--- a/crates/wgrapier/src/dynamics/joint.wgsl
+++ b/crates/wgrapier/src/dynamics/joint.wgsl
@@ -1,0 +1,149 @@
+#define_import_path wgrapier::dynamics::joint
+
+#if DIM == 2
+    #import wgebra::sim2 as Pose
+#else
+    #import wgebra::sim3 as Pose
+#endif
+
+#if DIM == 2
+const SPATIAL_DIM: u32 = 3;
+#else
+const SPATIAL_DIM: u32 = 6;
+#endif
+
+#if DIM == 2
+const LIN_AXES_MASK: u32 = 1 + (1 << 1) + (1 << 2);
+const ANG_AXES_MASK: u32 = (1 << 3) + (1 << 4) + (1 << 5);
+#else
+const LIN_AXES_MASK: u32 = 1 + (1 << 1);
+const ANG_AXES_MASK: u32 = 1 << 2;
+#endif
+
+struct ImpulseJoint {
+    body_a: u32,
+    body_b: u32,
+    data: GenericJoint,
+}
+
+/// A generic (6 DOFs in 3D or 3 DOFs in 2D) joint.
+struct GenericJoint {
+    /// The joint’s frame, expressed in the first rigid-body’s local-space.
+    local_frame_a: Transform,
+    /// The joint’s frame, expressed in the second rigid-body’s local-space.
+    local_frame_b: Transform,
+    /// The degrees-of-freedoms locked by this joint.
+    locked_axes: u32,
+    /// The degrees-of-freedoms limited by this joint.
+    limit_axes: u32,
+    /// The degrees-of-freedoms motorised by this joint.
+    motor_axes: u32,
+    /// The coupled degrees of freedom of this joint.
+    ///
+    /// Note that coupling degrees of freedoms (DoF) changes the interpretation of the coupled joint’s limits and motors.
+    /// If multiple linear DoF are limited/motorized, only the limits/motor configuration for the first
+    /// coupled linear DoF is applied to all coupled linear DoF. Similarly, if multiple angular DoF are limited/motorized
+    /// only the limits/motor configuration for the first coupled angular DoF is applied to all coupled angular DoF.
+    coupled_axes: u32,
+    /// The limits, along each degree of freedoms of this joint.
+    ///
+    /// Note that the limit must also be explicitly enabled by the `limit_axes` bitmask.
+    /// For coupled degrees of freedoms (DoF), only the first linear (resp. angular) coupled DoF limit and `limit_axis`
+    /// bitmask is applied to the coupled linear (resp. angular) axes.
+    limits: array<JointLimits, SPATIAL_DIM>,
+    /// The motors, along each degree of freedoms of this joint.
+    ///
+    /// Note that the motor must also be explicitly enabled by the `motor_axes` bitmask.
+    /// For coupled degrees of freedoms (DoF), only the first linear (resp. angular) coupled DoF motor and `motor_axes`
+    /// bitmask is applied to the coupled linear (resp. angular) axes.
+    motors: array<JointMotor, SPATIAL_DIM>,
+}
+
+/// Limits that restrict a joint's range of motion along one axis.
+///
+/// Use to constrain how far a joint can move/rotate. Examples:
+/// - Door that only opens 90°: revolute joint with limits `[0.0, PI/2.0]`
+/// - Piston with 2-unit stroke: prismatic joint with limits `[0.0, 2.0]`
+/// - Elbow that bends 0-150°: revolute joint with limits `[0.0, 5*PI/6]`
+///
+/// When a joint hits its limit, forces are applied to prevent further movement in that direction.
+struct JointLimits {
+    /// Minimum allowed value (angle for revolute, distance for prismatic).
+    min: f32,
+    /// Maximum allowed value (angle for revolute, distance for prismatic).
+    max: f32,
+    /// Internal: impulse being applied to enforce the limit.
+    impulse: f32,
+}
+
+/// A powered motor that drives a joint toward a target position/velocity.
+///
+/// Motors add actuation to joints - they apply forces to make the joint move toward
+/// a desired state. Think of them as servos, electric motors, or hydraulic actuators.
+///
+/// ## Two control modes
+///
+/// 1. **Velocity control**: Set `target_vel` to make the motor spin/slide at constant speed
+/// 2. **Position control**: Set `target_pos` with `stiffness`/`damping` to reach a target angle/position
+struct JointMotor {
+    /// Target velocity (units/sec for prismatic, rad/sec for revolute).
+    target_vel: f32,
+    /// Target position (units for prismatic, radians for revolute).
+    target_pos: f32,
+    /// Spring constant - how strongly to pull toward target position.
+    stiffness: f32,
+    /// Damping coefficient - resistance to motion (prevents oscillation).
+    damping: f32,
+    /// Maximum force the motor can apply (Newtons for prismatic, Nm for revolute).
+    max_force: f32,
+    /// Internal: current impulse being applied.
+    impulse: f32,
+    /// Force-based or acceleration-based motor model.
+    model: u32,
+}
+
+/// Spring constants auto-scale with mass (easier to tune, recommended).
+const ACCELERATION_BASED: u32 = 0;
+/// Spring constants produce absolute forces (mass-dependent).
+const FORCE_BASED: u32 = 1;
+
+struct MotorParameters {
+    erp_inv_dt: f32,
+    cfm_coeff: f32,
+    cfm_gain: f32,
+    target_pos: f32,
+    target_vel: f32,
+    max_impulse: f32,
+}
+
+fn motor_params(motor: JointMotor, dt: f32) -> MotorParameters {
+    if motor.model == ACCELERATION_BASED {
+        let erp_inv_dt = motor.stiffness * pseudo_inv(dt * motor.stiffness + motor.damping);
+        let cfm_coeff = pseudo_inv(dt * dt * motor.stiffness + dt * motor.damping);
+
+        return MotorParameters(
+            erp_inv_dt,
+            cfm_coeff,
+            0.0,
+            motor.target_pos,
+            motor.target_vel,
+            motor.max_force * dt,
+        );
+    } else { // FORCE_BASED
+        let erp_inv_dt = motor.stiffness * pseudo_inv(dt * motor.stiffness + motor.damping);
+        let cfm_gain = pseudo_inv(dt * dt * motor.stiffness + dt * motor.damping);
+
+        return MotorParameters(
+            erp_inv_dt,
+            0.0, // cfm_coeff,
+            cfm_gain,
+            motor.target_pos,
+            motor.target_vel,
+            motor.max_force * dt,
+        );
+    }
+}
+
+fn pseudo_inv(x: f32) -> f32 {
+    return select(1.0 / x, 0.0, x == 0.0);
+}

--- a/crates/wgrapier/src/dynamics/joint_constraint.wgsl
+++ b/crates/wgrapier/src/dynamics/joint_constraint.wgsl
@@ -1,0 +1,52 @@
+#define_import_path wgrapier::dynamics::joint_constraint
+
+#import wgrapier::dynamics::joint as Joint
+
+struct MotorParameters {
+    erp_inv_dt: f32,
+    cfm_coeff: f32,
+    cfm_gain: f32,
+    target_pos: f32,
+    target_vel: f32,
+    max_impulse: f32,
+}
+
+struct JointSolverBody {
+    im: Vector,
+#if DIM == 2
+    ii: f32,
+#else
+    ii: mat3x3<f32>,
+#endif
+    // TODO: is this still needed now that the solver body poses are expressed at the center of mass?
+    world_com: Vector,
+    solver_vel: u32,
+}
+
+struct JointConstraint {
+    solver_vel_a: u32,
+    solver_vel_b: u32,
+    im_a: Vector,
+    im_b: Vector,
+
+    /// The constraints for a joint. Up to 6 in 3D, and up to 3 in 2D.
+    elements: array<JointConstraintElement, Joint::SPATIAL_DIM>,
+    /// The number of active `JointConstraint::elements`.
+    len: u32,
+}
+
+struct JointConstraintElement {
+    joint_id: u32,
+    impulse: f32,
+    impulse_bounds: vec2<f32>,
+    lin_jac: Vector,
+    ang_jac_a: AngVector,
+    ang_jac_b: AngVector,
+    ii_ang_jac_a: AngVector,
+    ii_ang_jac_b: AngVector,
+    inv_lhs: f32,
+    rhs: f32,
+    rhs_wo_bias: f32,
+    cfm_gain: f32,
+    cfm_coeff: f32,
+}

--- a/crates/wgrapier/src/dynamics/joint_constraint_builder.wgsl
+++ b/crates/wgrapier/src/dynamics/joint_constraint_builder.wgsl
@@ -1,0 +1,1017 @@
+#define_import_path wgrapier::dynamics::joint_constraint_builder
+
+#import wgrapier::body as Body;
+#import wgrapier::dynamics::sim_params as Params;
+#import wgrapier::dynamics::joint as Joint
+#import wgrapier::dynamics::joint_constraint as JointConstraint
+
+#if DIM == 2
+    #import wgebra::sim2 as Pose
+    #import wgebra::rot2 as Rot
+const DIM: u32 = 2;
+#else
+    #import wgebra::sim3 as Pose
+    #import wgebra::quat as Rot
+const DIM: u32 = 3;
+#endif
+
+const MAX: f32 = 1.0e20;
+
+@group(0) @binding(0)
+var<uniform> joints_len: u32;
+@group(0) @binding(1)
+var<storage, read> joints: array<Joint::ImpulseJoint>;
+@group(0) @binding(2)
+var<storage, read_write> builders: array<JointConstraintBuilder>;
+@group(0) @binding(3)
+var<storage, read_write> constraints: array<JointConstraint::JointConstraint>;
+@group(0) @binding(4)
+var<storage, read_write> curr_color: u32;
+@group(0) @binding(5)
+var<storage, read> color_groups: array<u32>;
+
+
+@group(1) @binding(0)
+var<uniform> params: Params::SimParams;
+@group(1) @binding(1)
+var<storage, read_write> poses: array<Transform>;
+@group(1) @binding(2)
+var<storage, read_write> solver_vels: array<Body::Velocity>;
+@group(1) @binding(3)
+var<storage, read> local_mprops: array<Body::LocalMassProperties>;
+@group(1) @binding(4)
+var<storage, read> mprops: array<Body::WorldMassProperties>;
+
+const WORKGROUP_SIZE: u32 = 64;
+
+@compute @workgroup_size(1, 1, 1)
+fn reset_color() {
+    // NOTE: for joints, our first colors start at 0.
+    curr_color = 0u;
+}
+
+@compute @workgroup_size(1, 1, 1)
+fn inc_color() {
+    curr_color += 1;
+}
+
+@compute @workgroup_size(WORKGROUP_SIZE, 1, 1)
+fn init(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
+    let num_threads = num_workgroups.x * WORKGROUP_SIZE * num_workgroups.y * num_workgroups.z;
+    for (var i = invocation_id.x; i < joints_len; i += num_threads) {
+        init_builder_and_constraint(i, i, i); // TODO: will these three indices ever be different?
+    }
+}
+
+@compute @workgroup_size(WORKGROUP_SIZE, 1, 1)
+fn update(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
+    let num_threads = num_workgroups.x * WORKGROUP_SIZE * num_workgroups.y * num_workgroups.z;
+    for (var i = invocation_id.x; i < joints_len; i += num_threads) {
+        update_constraint(i, i); // TODO: will these two indices ever be different?
+    }
+}
+
+@compute @workgroup_size(WORKGROUP_SIZE, 1, 1)
+fn remove_bias(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
+    let num_threads = num_workgroups.x * WORKGROUP_SIZE * num_workgroups.y * num_workgroups.z;
+    for (var i = invocation_id.x; i < joints_len; i += num_threads) {
+        for (var j = 0u; j < constraints[i].len; j++) {
+            constraints[i].elements[j].rhs = constraints[i].elements[j].rhs_wo_bias;
+        }
+    }
+}
+
+@compute @workgroup_size(WORKGROUP_SIZE, 1, 1)
+fn solve(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
+    let num_threads = num_workgroups.x * WORKGROUP_SIZE * num_workgroups.y * num_workgroups.z;
+    var start = 0u;
+    let end = color_groups[curr_color];
+
+    if curr_color > 0u {
+        start = color_groups[curr_color - 1u];
+    }
+
+    for (var i = start + invocation_id.x; i < end; i += num_threads) {
+        solve_constraint(i); // TODO: will these three indices ever be different?
+    }
+}
+
+struct JointConstraintBuilder {
+    body1: u32,
+    body2: u32,
+    joint_id: u32,
+    joint: Joint::GenericJoint,
+    constraint_id: u32,
+}
+
+fn init_builder_and_constraint(
+    joint_id: u32,
+    out_builder_id: u32,
+    constraint_id: u32,
+) {
+    let body1 = joints[joint_id].body_a;
+    let body2 = joints[joint_id].body_b;
+
+    var joint_data = joints[joint_id].data;
+
+    // TODO: if we switch to solver body poses given in center-of-mass space,
+    // we need to transform the anchors to that space.
+    if all(local_mprops[body1].inv_mass == Vector(0.0)) && false {
+        joint_data.local_frame_a = Pose::mul(poses[body1], joint_data.local_frame_a);
+    } else {
+        #if DIM == 2
+        joint_data.local_frame_a.translation -= local_mprops[body1].com;
+        #else
+        joint_data.local_frame_a.translation_scale -= vec4(local_mprops[body1].com, 0.0);
+        #endif
+    }
+
+    if all(local_mprops[body2].inv_mass == Vector(0.0)) && false {
+        joint_data.local_frame_b = Pose::mul(poses[body2], joint_data.local_frame_b);
+    } else {
+        #if DIM == 2
+        joint_data.local_frame_b.translation -= local_mprops[body2].com;
+        #else
+        joint_data.local_frame_b.translation_scale -= vec4(local_mprops[body2].com, 0.0);
+        #endif
+    }
+
+    builders[out_builder_id] = JointConstraintBuilder(
+        body1,
+        body2,
+        joint_id,
+        joint_data,
+        constraint_id,
+    );
+    constraints[constraint_id].solver_vel_a = body1;
+    constraints[constraint_id].solver_vel_b = body2;
+    constraints[constraint_id].im_a = local_mprops[body1].inv_mass;
+    constraints[constraint_id].im_b = local_mprops[body2].inv_mass;
+    constraints[constraint_id].len = 0; // Constraint elements will be filled later.
+}
+
+fn update_constraint(
+    builder_id: u32,
+    constraint_id: u32,
+) {
+    // NOTE: right now, the "update", is basically reconstructing all the
+    //       constraints entirely. Could we make this more incremental?
+    let joint = &builders[builder_id].joint;
+    let body1 = builders[builder_id].body1;
+    let body2 = builders[builder_id].body2;
+    let pose1 = poses[body1];
+    let pose2 = poses[body2];
+    let mprops1 = mprops[body1];
+    let mprops2 = mprops[body2];
+
+    let frame1 = Pose::mul(pose1, joint.local_frame_a);
+    let frame2 = Pose::mul(pose2, joint.local_frame_b);
+
+    // TODO: needs adjustment if the pose origin isn’t the same as the
+    //       center of mass.
+    #if DIM == 2
+    let world_com1 = pose1.translation;
+    let world_com2 = pose2.translation;
+    #else
+    let world_com1 = pose1.translation_scale.xyz;
+    let world_com2 = pose2.translation_scale.xyz;
+    #endif
+
+    let joint_body1 = JointConstraint::JointSolverBody(
+        mprops1.inv_mass,
+        mprops1.inv_inertia,
+        world_com1,
+        body1,
+    );
+    let joint_body2 = JointConstraint::JointSolverBody(
+        mprops2.inv_mass,
+        mprops2.inv_inertia,
+        world_com2,
+        body2,
+    );
+
+    var len = 0u;
+    let locked_axes = joint.locked_axes;
+    let motor_axes = joint.motor_axes & ~locked_axes;
+    let limit_axes = joint.limit_axes & ~locked_axes;
+    let coupled_axes = joint.coupled_axes;
+
+    // The has_lin/ang_coupling test is needed to avoid shl overflow later.
+    let has_lin_coupling = (coupled_axes & Joint::LIN_AXES_MASK) != 0;
+    let first_coupled_lin_axis_id =
+        countTrailingZeros(coupled_axes & Joint::LIN_AXES_MASK);
+
+#if DIM == 3
+    let has_ang_coupling = (coupled_axes & Joint::ANG_AXES_MASK) != 0;
+    let first_coupled_ang_axis_id =
+        countTrailingZeros(coupled_axes & Joint::ANG_AXES_MASK);
+#endif
+
+    let helper = new_helper(
+        frame1,
+        frame2,
+        mprops1.com,
+        mprops2.com,
+        locked_axes,
+    );
+
+    var start = len;
+    for (var i = DIM; i < Joint::SPATIAL_DIM; i++) {
+        if ((motor_axes & ~coupled_axes) & (1u << i)) != 0u {
+            let motor_params = Joint::motor_params(joint.motors[i], params.dt);
+            constraints[constraint_id].elements[len] = motor_angular(
+                helper,
+                constraint_id, // TODO: is this really useful?
+                joint_body1,
+                joint_body2,
+                i - DIM,
+                motor_params,
+            );
+            len += 1u;
+        }
+    }
+
+    for (var i = 0u; i < DIM; i++) {
+        if ((motor_axes & ~coupled_axes) & (1u << i)) != 0u {
+            var limits = vec2(-MAX, MAX);
+
+            if (limit_axes & (1u << i)) != 0u {
+               limits = vec2(joint.limits[i].min, joint.limits[i].max);
+            }
+
+            let motor_params = Joint::motor_params(joint.motors[i], params.dt);
+
+            constraints[constraint_id].elements[len] = motor_linear(
+                helper,
+                constraint_id,
+                joint_body1,
+                joint_body2,
+                i,
+                motor_params,
+                limits,
+            );
+            len += 1u;
+        }
+    }
+
+    if ((motor_axes & coupled_axes) & Joint::ANG_AXES_MASK) != 0u {
+        // TODO: coupled angular motor constraint.
+    }
+
+    if ((motor_axes & coupled_axes) & Joint::LIN_AXES_MASK) != 0u {
+        var limits = vec2(-MAX, MAX);
+        if (limit_axes & (1u << first_coupled_lin_axis_id)) != 0u {
+            limits = vec2(
+                joint.limits[first_coupled_lin_axis_id].min,
+                joint.limits[first_coupled_lin_axis_id].max,
+            );
+        }
+
+        let motor_params = Joint::motor_params(joint.motors[first_coupled_lin_axis_id], params.dt);
+
+        constraints[constraint_id].elements[len] = motor_linear_coupled(
+            helper,
+            constraint_id,
+            joint_body1,
+            joint_body2,
+            coupled_axes,
+            motor_params,
+            limits,
+        );
+        len += 1u;
+    }
+
+    orthogonalize_constraints(constraint_id, start, len);
+
+    start = len;
+    for (var i = DIM; i < Joint::SPATIAL_DIM; i++) {
+        if (locked_axes & (1u << i)) != 0u {
+            constraints[constraint_id].elements[len] = lock_angular(
+                helper,
+                constraint_id,
+                joint_body1,
+                joint_body2,
+                i - DIM,
+            );
+            len += 1u;
+        }
+    }
+    for (var i = 0u; i < DIM; i++) {
+        if (locked_axes & (1u << i)) != 0u {
+            constraints[constraint_id].elements[len] =
+                lock_linear(helper, constraint_id, joint_body1, joint_body2, i);
+            len += 1u;
+        }
+    }
+
+    for (var i = DIM; i < Joint::SPATIAL_DIM; i++) {
+        if ((limit_axes & ~coupled_axes) & (1u << i)) != 0u {
+            constraints[constraint_id].elements[len] = limit_angular(
+                helper,
+                constraint_id,
+                joint_body1,
+                joint_body2,
+                i - DIM,
+                vec2(joint.limits[i].min, joint.limits[i].max),
+            );
+            len += 1u;
+        }
+    }
+    for (var i = 0u; i < DIM; i++) {
+        if ((limit_axes & ~coupled_axes) & (1u << i)) != 0u {
+            constraints[constraint_id].elements[len] = limit_linear(
+                helper,
+                constraint_id,
+                joint_body1,
+                joint_body2,
+                i,
+                vec2(joint.limits[i].min, joint.limits[i].max),
+            );
+            len += 1u;
+        }
+    }
+
+//    #[cfg(feature = "dim3")]
+//    if has_ang_coupling && (limit_axes & (1 << first_coupled_ang_axis_id)) != 0 {
+//        constraints[constraint_id].elements[len] = helper.limit_angular_coupled(
+//            constraint_id,
+//            joint_body1,
+//            joint_body2,
+//            coupled_axes,
+//            [
+//                joint.limits[first_coupled_ang_axis_id].min,
+//                joint.limits[first_coupled_ang_axis_id].max,
+//            ],
+//            WritebackId::Limit(first_coupled_ang_axis_id),
+//        );
+//        len += 1;
+//    }
+
+    if has_lin_coupling && (limit_axes & (1u << first_coupled_lin_axis_id)) != 0u {
+        constraints[constraint_id].elements[len] = limit_linear_coupled(
+            helper,
+            constraint_id,
+            joint_body1,
+            joint_body2,
+            coupled_axes,
+            vec2(
+                joint.limits[first_coupled_lin_axis_id].min,
+                joint.limits[first_coupled_lin_axis_id].max,
+            ),
+        );
+        len += 1u;
+    }
+
+    orthogonalize_constraints(constraint_id, start, len);
+    constraints[constraint_id].len = len;
+}
+
+
+struct JointConstraintHelper {
+#if DIM == 2
+    basis: mat2x2<f32>,
+    cmat1_basis: vec2<f32>,
+    cmat2_basis: vec2<f32>,
+    lin_err: Vector,
+    ang_err: Rot::Rot2
+#else
+    basis: mat3x3<f32>,
+    basis2: mat3x3<f32>, // TODO: used only for angular coupling. Can we avoid storing this?
+    cmat1_basis: mat3x3<f32>,
+    cmat2_basis: mat3x3<f32>,
+    ang_basis: mat3x3<f32>,
+    lin_err: Vector,
+    ang_err: Rot::Quat
+#endif
+}
+
+fn new_helper(
+    frame1_: Transform,
+    frame2: Transform,
+    world_com1: Vector,
+    world_com2: Vector,
+    locked_lin_axes: u32,
+) -> JointConstraintHelper {
+#if DIM == 2
+    var frame1 = frame1_;
+    let basis = Rot::toMatrix(frame1.rotation);
+    let lin_err = frame2.translation - frame1.translation;
+
+    // Adjust the point of application of the force for the first body,
+    // by snapping free axes to the second frame’s center (to account for
+    // the allowed relative movement).
+    {
+        var new_center1 = frame2.translation; // First, assume all dofs are free.
+
+        // Then snap the locked ones.
+        for (var i = 0u; i < DIM; i++) {
+            if (locked_lin_axes & (1u << i)) != 0u {
+                let axis = basis[i];
+                new_center1 -= axis * dot(lin_err, axis);
+            }
+        }
+        frame1.translation = new_center1;
+    }
+
+    let r1 = frame1.translation - world_com1;
+    let r2 = frame2.translation - world_com2;
+
+    let cmat1 = gcross_matrix(r1);
+    let cmat2 = gcross_matrix(r2);
+
+    var ang_err = Rot::mul(Rot::inv(frame1.rotation), frame2.rotation);
+
+    return JointConstraintHelper(
+        basis,
+        cmat1 * basis,
+        cmat2 * basis,
+        lin_err,
+        ang_err,
+    );
+#else
+    var frame1 = frame1_;
+    let basis = Rot::toMatrix(frame1.rotation);
+    let lin_err = frame2.translation_scale.xyz - frame1.translation_scale.xyz;
+
+    // Adjust the point of application of the force for the first body,
+    // by snapping free axes to the second frame’s center (to account for
+    // the allowed relative movement).
+    {
+        var new_center1 = frame2.translation_scale.xyz; // First, assume all dofs are free.
+
+        // Then snap the locked ones.
+        for (var i = 0u; i < DIM; i++) {
+            if (locked_lin_axes & (1u << i)) != 0u {
+                let axis = basis[i];
+                new_center1 -= axis * dot(lin_err, axis);
+            }
+        }
+        frame1.translation_scale = vec4(new_center1, frame1.translation_scale.w);
+    }
+
+    let r1 = frame1.translation_scale.xyz - world_com1;
+    let r2 = frame2.translation_scale.xyz - world_com2;
+
+    let cmat1 = gcross_matrix(r1);
+    let cmat2 = gcross_matrix(r2);
+
+    var ang_basis = transpose(Rot::diff_conj1_2(frame1.rotation, frame2.rotation));
+    var ang_err = Rot::mul(Rot::inv(frame1.rotation), frame2.rotation);
+    let sgn = select(-1.0, 1.0, dot(frame1.rotation.coords, frame2.rotation.coords) > 0.0);
+    ang_basis *= sgn;
+    ang_err.coords *= sgn;
+
+    return JointConstraintHelper(
+        basis,
+        Rot::toMatrix(frame2.rotation),
+        cmat1 * basis,
+        cmat2 * basis,
+        ang_basis,
+        lin_err,
+        ang_err,
+    );
+#endif
+}
+
+fn limit_linear(
+    helper: JointConstraintHelper,
+    joint_id: u32,
+    body1: JointConstraint::JointSolverBody,
+    body2: JointConstraint::JointSolverBody,
+    limited_axis: u32,
+    limits: vec2<f32>,
+) -> JointConstraint::JointConstraintElement {
+    var constraint =
+        lock_linear(helper, joint_id, body1, body2, limited_axis);
+
+    let dist = dot(helper.lin_err, constraint.lin_jac);
+    let min_enabled = dist <= limits[0];
+    let max_enabled = limits[1] <= dist;
+
+    let erp_inv_dt = Params::joint_erp_inv_dt(params);
+    let cfm_coeff = Params::joint_cfm_coeff(params);
+    let rhs_bias =
+        (max(dist - limits[1], 0.0) - max(limits[0] - dist, 0.0)) * erp_inv_dt;
+    constraint.rhs = constraint.rhs_wo_bias + rhs_bias;
+    constraint.cfm_coeff = cfm_coeff;
+    constraint.impulse_bounds = vec2(
+        select(0.0, -MAX, min_enabled),
+        select(0.0, MAX, max_enabled),
+    );
+
+    return constraint;
+}
+
+fn limit_linear_coupled(
+    helper: JointConstraintHelper,
+    joint_id: u32,
+    body1: JointConstraint::JointSolverBody,
+    body2: JointConstraint::JointSolverBody,
+    coupled_axes: u32,
+    limits: vec2<f32>,
+) -> JointConstraint::JointConstraintElement {
+    var lin_jac = Vector(0.0);
+    var ang_jac1 = AngVector(0.0);
+    var ang_jac2 = AngVector(0.0);
+
+    for (var i = 0u; i < DIM; i++) {
+        if (coupled_axes & (1u << i)) != 0u {
+            let coeff = dot(helper.basis[i], helper.lin_err);
+            lin_jac += helper.basis[i] * coeff;
+#if DIM == 2
+            ang_jac1 += helper.cmat1_basis[i] * coeff;
+            ang_jac2 += helper.cmat2_basis[i] * coeff;
+#else
+            ang_jac1 += helper.cmat1_basis[i] * coeff;
+            ang_jac2 += helper.cmat2_basis[i] * coeff;
+#endif
+        }
+    }
+
+    // FIXME: handle min limit too.
+
+    let dist = length(lin_jac);
+    let inv_dist = pseudo_inv(dist);
+    lin_jac *= inv_dist;
+    ang_jac1 *= inv_dist;
+    ang_jac2 *= inv_dist;
+
+    let rhs_wo_bias = min(dist - limits[1], 0.0) * Params::inv_dt(params);
+
+    let ii_ang_jac1 = body1.ii * ang_jac1;
+    let ii_ang_jac2 = body2.ii * ang_jac2;
+
+    let erp_inv_dt = Params::joint_erp_inv_dt(params);
+    let cfm_coeff = Params::joint_cfm_coeff(params);
+    let rhs_bias = max(dist - limits[1], 0.0) * erp_inv_dt;
+    let rhs = rhs_wo_bias + rhs_bias;
+    let impulse_bounds = vec2(0.0, MAX);
+
+    return JointConstraint::JointConstraintElement(
+        joint_id,
+        0.0, // impulse
+        impulse_bounds,
+        lin_jac,
+        ang_jac1,
+        ang_jac2,
+        ii_ang_jac1,
+        ii_ang_jac2,
+        0.0, // inv_lhs will be set during orthogonalization.
+        rhs,
+        rhs_wo_bias,
+        0.0, // cfm_gain
+        cfm_coeff,
+    );
+}
+
+fn motor_linear(
+    helper: JointConstraintHelper,
+    joint_id: u32,
+    body1: JointConstraint::JointSolverBody,
+    body2: JointConstraint::JointSolverBody,
+    motor_axis: u32,
+    motor_params: Joint::MotorParameters,
+    limits: vec2<f32>,
+) -> JointConstraint::JointConstraintElement {
+    let inv_dt = Params::inv_dt(params);
+    var constraint =
+        lock_linear(helper, joint_id, body1, body2, motor_axis);
+
+    var rhs_wo_bias = 0.0;
+    if motor_params.erp_inv_dt != 0.0 {
+        let dist = dot(helper.lin_err, constraint.lin_jac);
+        rhs_wo_bias += (dist - motor_params.target_pos) * motor_params.erp_inv_dt;
+    }
+
+    var target_vel = motor_params.target_vel;
+    if any(limits != vec2(-MAX, MAX)) {
+        let dist = dot(helper.lin_err, constraint.lin_jac);
+        target_vel =
+            clamp(target_vel, (limits[0] - dist) * inv_dt, (limits[1] - dist) * inv_dt);
+    };
+
+    rhs_wo_bias += -target_vel;
+
+    constraint.cfm_coeff = motor_params.cfm_coeff;
+    constraint.cfm_gain = motor_params.cfm_gain;
+    constraint.impulse_bounds = vec2(-motor_params.max_impulse, motor_params.max_impulse);
+    constraint.rhs = rhs_wo_bias;
+    constraint.rhs_wo_bias = rhs_wo_bias;
+    return constraint;
+}
+
+fn motor_linear_coupled(
+    helper: JointConstraintHelper,
+    joint_id: u32,
+    body1: JointConstraint::JointSolverBody,
+    body2: JointConstraint::JointSolverBody,
+    coupled_axes: u32,
+    motor_params: Joint::MotorParameters,
+    limits: vec2<f32>,
+) -> JointConstraint::JointConstraintElement {
+    let inv_dt = Params::inv_dt(params);
+
+    var lin_jac = Vector(0.0);
+    var ang_jac1 = AngVector(0.0);
+    var ang_jac2 = AngVector(0.0);
+
+    for (var i = 0u; i < DIM; i++) {
+        if (coupled_axes & (1u << i)) != 0u {
+            let coeff = dot(helper.basis[i], helper.lin_err);
+            lin_jac += helper.basis[i] * coeff;
+#if DIM == 2
+            ang_jac1 += helper.cmat1_basis[i] * coeff;
+            ang_jac2 += helper.cmat2_basis[i] * coeff;
+#else
+            ang_jac1 += helper.cmat1_basis[i] * coeff;
+            ang_jac2 += helper.cmat2_basis[i] * coeff;
+#endif
+        }
+    }
+
+    let dist = length(lin_jac);
+    let inv_dist = pseudo_inv(dist);
+    lin_jac *= inv_dist;
+    ang_jac1 *= inv_dist;
+    ang_jac2 *= inv_dist;
+
+    var rhs_wo_bias = 0.0;
+    if motor_params.erp_inv_dt != 0.0 {
+        rhs_wo_bias += (dist - motor_params.target_pos) * motor_params.erp_inv_dt;
+    }
+
+    var target_vel = motor_params.target_vel;
+    if any(limits != vec2(-MAX, MAX)) {
+        target_vel =
+            clamp(target_vel, (limits[0] - dist) * inv_dt, (limits[1] - dist) * inv_dt);
+    };
+
+    rhs_wo_bias += -target_vel;
+
+    let ii_ang_jac1 = body1.ii * ang_jac1;
+    let ii_ang_jac2 = body2.ii * ang_jac2;
+
+    return JointConstraint::JointConstraintElement(
+        joint_id,
+        0.0, // impulse
+        vec2(-motor_params.max_impulse, motor_params.max_impulse),
+        lin_jac,
+        ang_jac1,
+        ang_jac2,
+        ii_ang_jac1,
+        ii_ang_jac2,
+        0.0, // inv_lhs will be set during orthogonalization.
+        rhs_wo_bias,
+        rhs_wo_bias,
+        motor_params.cfm_gain,
+        motor_params.cfm_coeff,
+    );
+}
+
+fn lock_linear(
+    helper: JointConstraintHelper,
+    joint_id: u32,
+    body1: JointConstraint::JointSolverBody,
+    body2: JointConstraint::JointSolverBody,
+    locked_axis: u32,
+) -> JointConstraint::JointConstraintElement {
+    let lin_jac = helper.basis[locked_axis];
+    let ang_jac1 = helper.cmat1_basis[locked_axis];
+    let ang_jac2 = helper.cmat2_basis[locked_axis];
+
+    let rhs_wo_bias = 0.0;
+    let erp_inv_dt = Params::joint_erp_inv_dt(params);
+    let cfm_coeff = Params::joint_cfm_coeff(params);
+    let rhs_bias = dot(lin_jac, helper.lin_err) * erp_inv_dt;
+
+    let ii_ang_jac1 = body1.ii * ang_jac1;
+    let ii_ang_jac2 = body2.ii * ang_jac2;
+
+    return JointConstraint::JointConstraintElement(
+        joint_id,
+        0.0,             // impulse
+        vec2(-MAX, MAX), // impulse_bounds
+        lin_jac,         // lin_jac
+        ang_jac1,
+        ang_jac2,
+        ii_ang_jac1,
+        ii_ang_jac2,
+        0.0,             // inv_lhs will be set during orthogonalization.
+        rhs_wo_bias + rhs_bias,
+        rhs_wo_bias,
+        0.0,             // cfm_gain
+        cfm_coeff,
+    );
+}
+
+fn limit_angular(
+    helper: JointConstraintHelper,
+    joint_id: u32,
+    body1: JointConstraint::JointSolverBody,
+    body2: JointConstraint::JointSolverBody,
+    limited_axis: u32,
+    limits: vec2<f32>,
+) -> JointConstraint::JointConstraintElement {
+    let s_limits = vec2(sin(limits[0] * 0.5), sin(limits[1] * 0.5));
+#if DIM == 2
+    let s_ang = sin(Rot::angle(helper.ang_err) * 0.5);
+#else
+    let s_ang = Rot::imag(helper.ang_err)[limited_axis];
+#endif
+    let min_enabled = s_ang <= s_limits[0];
+    let max_enabled = s_limits[1] <= s_ang;
+
+    let impulse_bounds = vec2(
+        select(0.0, -MAX, min_enabled),
+        select(0.0, MAX, max_enabled),
+    );
+
+#if DIM == 2
+    let ang_jac = 1.0;
+#else
+    let ang_jac = helper.ang_basis[limited_axis];
+#endif
+    let rhs_wo_bias = 0.0;
+    let erp_inv_dt = Params::joint_erp_inv_dt(params);
+    let cfm_coeff = Params::joint_cfm_coeff(params);
+    let rhs_bias = (max(s_ang - s_limits[1], 0.0)
+        - max(s_limits[0] - s_ang, 0.0))
+        * erp_inv_dt;
+
+    let ii_ang_jac1 = body1.ii * ang_jac;
+    let ii_ang_jac2 = body2.ii * ang_jac;
+
+    return JointConstraint::JointConstraintElement(
+        joint_id,
+        0.0,            // impulse
+        impulse_bounds,
+        Vector(),       // lin_jac
+        ang_jac,
+        ang_jac,
+        ii_ang_jac1,
+        ii_ang_jac2,
+        0.0,            // inv_lhs will be set during orthogonalization.
+        rhs_wo_bias + rhs_bias,
+        rhs_wo_bias,
+        0.0,            // cfm_gain
+        cfm_coeff,
+    );
+}
+
+fn motor_angular(
+    helper: JointConstraintHelper,
+    joint_id: u32,
+    body1: JointConstraint::JointSolverBody,
+    body2: JointConstraint::JointSolverBody,
+    motor_axis: u32,
+    motor_params: Joint::MotorParameters,
+) -> JointConstraint::JointConstraintElement {
+#if DIM == 2
+    let ang_jac = 1.0;
+#else
+    let ang_jac = helper.basis[motor_axis];
+#endif
+
+    var rhs_wo_bias = 0.0;
+    if motor_params.erp_inv_dt != 0.0 {
+#if DIM == 2
+        let ang_dist = Rot::angle(helper.ang_err);
+#else
+        // Clamp the component from -1.0 to 1.0 to account for slight imprecision
+        let clamped_err = clamp(Rot::imag(helper.ang_err)[motor_axis], -1.0, 1.0);
+        let ang_dist = asin(clamped_err) * 2.0;
+#endif
+
+        let target_ang = motor_params.target_pos;
+        rhs_wo_bias += smallest_abs_diff_between_angles(ang_dist, target_ang)
+            * motor_params.erp_inv_dt;
+    }
+
+    rhs_wo_bias += -motor_params.target_vel;
+
+    let ii_ang_jac1 = body1.ii * ang_jac;
+    let ii_ang_jac2 = body2.ii * ang_jac;
+
+    return JointConstraint::JointConstraintElement(
+        joint_id,
+        0.0,         // impulse
+        vec2(-motor_params.max_impulse, motor_params.max_impulse), // impulse_bounds
+        Vector(),    // lin_jac
+        ang_jac,
+        ang_jac,
+        ii_ang_jac1,
+        ii_ang_jac2,
+        0.0,         // inv_lhs will be set during orthogonalization.
+        rhs_wo_bias, // rhs
+        rhs_wo_bias,
+        motor_params.cfm_gain,
+        motor_params.cfm_coeff,
+    );
+}
+
+fn lock_angular(
+    helper: JointConstraintHelper,
+    joint_id: u32,
+    body1: JointConstraint::JointSolverBody,
+    body2: JointConstraint::JointSolverBody,
+    locked_axis: u32,
+) -> JointConstraint::JointConstraintElement {
+#if DIM == 2
+    let ang_jac = 1.0;
+#else
+    let ang_jac = helper.ang_basis[locked_axis];
+#endif
+
+    let rhs_wo_bias = 0.0;
+    let erp_inv_dt = Params::joint_erp_inv_dt(params);
+    let cfm_coeff = Params::joint_cfm_coeff(params);
+#if DIM == 2
+    let rhs_bias = helper.ang_err.cos_sin.y * erp_inv_dt;
+#else
+    let rhs_bias = Rot::imag(helper.ang_err)[locked_axis] * erp_inv_dt;
+#endif
+    let ii_ang_jac1 = body1.ii * ang_jac;
+    let ii_ang_jac2 = body2.ii * ang_jac;
+
+    return JointConstraint::JointConstraintElement(
+        joint_id,
+        0.0,             // impulse
+        vec2(-MAX, MAX), // impulse_bounds
+        Vector(),        // lin_jac
+        ang_jac,
+        ang_jac,
+        ii_ang_jac1,
+        ii_ang_jac2,
+        0.0,             // inv_lhs will be set during orthogonalization.
+        rhs_wo_bias + rhs_bias,
+        rhs_wo_bias,
+        0.0,             // cfm_gain
+        cfm_coeff,
+    );
+}
+
+/// Orthogonalize the constraints and set their inv_lhs field.
+fn orthogonalize_constraints(id: u32, start: u32, end: u32) {
+    let len = end - start;
+
+    if len == 0 {
+        return;
+    }
+
+    let imsum = constraints[id].im_a + constraints[id].im_b;
+
+    // Use the modified Gram-Schmidt orthogonalization.
+    for (var j = start; j < end; j++) {
+        let dot_jj = dot(constraints[id].elements[j].lin_jac, imsum * constraints[id].elements[j].lin_jac)
+            + gdot(constraints[id].elements[j].ii_ang_jac_a, constraints[id].elements[j].ang_jac_a)
+            + gdot(constraints[id].elements[j].ii_ang_jac_b, constraints[id].elements[j].ang_jac_b);
+        let cfm_gain = dot_jj * constraints[id].elements[j].cfm_coeff + constraints[id].elements[j].cfm_gain;
+        let inv_dot_jj = pseudo_inv(dot_jj);
+        constraints[id].elements[j].inv_lhs = pseudo_inv(dot_jj + cfm_gain); // Don’t forget to update the inv_lhs.
+        constraints[id].elements[j].cfm_gain = cfm_gain;
+
+        if any(constraints[id].elements[j].impulse_bounds != vec2(-MAX, MAX)) {
+            // Don't remove constraints with limited forces from the others
+            // because they may not deliver the necessary forces to fulfill
+            // the removed parts of other constraints.
+            continue;
+        }
+
+        for (var i = j + 1u; i < end; i++) {
+            let dot_ij = dot(constraints[id].elements[i].lin_jac, imsum * constraints[id].elements[j].lin_jac)
+                + gdot(constraints[id].elements[i].ii_ang_jac_a, constraints[id].elements[j].ang_jac_a)
+                + gdot(constraints[id].elements[i].ii_ang_jac_b, constraints[id].elements[j].ang_jac_b);
+            let coeff = dot_ij * inv_dot_jj;
+
+            constraints[id].elements[i].lin_jac -= constraints[id].elements[j].lin_jac * coeff;
+            constraints[id].elements[i].ang_jac_a -= constraints[id].elements[j].ang_jac_a * coeff;
+            constraints[id].elements[i].ang_jac_b -= constraints[id].elements[j].ang_jac_b * coeff;
+            constraints[id].elements[i].ii_ang_jac_a -= constraints[id].elements[j].ii_ang_jac_a * coeff;
+            constraints[id].elements[i].ii_ang_jac_b -= constraints[id].elements[j].ii_ang_jac_b * coeff;
+            constraints[id].elements[i].rhs_wo_bias -= constraints[id].elements[j].rhs_wo_bias * coeff;
+            constraints[id].elements[i].rhs -= constraints[id].elements[j].rhs * coeff;
+        }
+    }
+}
+
+/*
+fn limit_angular_coupled(
+    helper: JointConstraintHelper,
+    joint_id: u32,
+    body1: JointConstraint::JointSolverBody,
+    body2: JointConstraint::JointSolverBody,
+    coupled_axes: u32,
+    limits: vec2<f32>,
+) -> JointConstraint::JointConstraintElement {
+    // NOTE: right now, this only supports exactly 2 coupled axes.
+    let ang_coupled_axes = coupled_axes >> DIM;
+    let not_coupled_index = ang_coupled_axes.trailing_ones() as u32;
+    let axis1 = helper.basis[not_coupled_index];
+    let axis2 = helper.basis2[not_coupled_index];
+
+    let rot = Rotation::rotation_between(&axis1, &axis2).unwrap_or_else(Rotation::identity);
+    let (ang_jac, angle) = rot
+        .axis_angle()
+        .map(|(axis, angle)| (axis.into_inner(), angle))
+        .unwrap_or_else(|| (axis1.orthonormal_basis()[0], 0.0));
+
+    let min_enabled = angle <= limits[0];
+    let max_enabled = limits[1] <= angle;
+
+    let impulse_bounds = vec2(
+        select(0.0, -MAX, min_enabled),
+        select(0.0, MAX, max_enabled),
+    );
+
+    let rhs_wo_bias = 0.0;
+
+    let erp_inv_dt = Params::joint_erp_inv_dt(params);
+    let cfm_coeff = Params::joint_cfm_coeff(params);
+    let rhs_bias = (max(angle - limits[1], 0.0) - max(limits[0] - angle, 0.0)) * erp_inv_dt;
+
+    let ii_ang_jac1 = body1.ii * ang_jac;
+    let ii_ang_jac2 = body2.ii * ang_jac;
+
+    return JointConstraint::JointConstraintElement(
+        joint_id,
+        0.0,            // impulse
+        impulse_bounds,
+        Vector(),       // lin_jac
+        ang_jac,
+        ang_jac,
+        ii_ang_jac1,
+        ii_ang_jac2,
+        0.0,            // inv_lhs will be set during orthogonalization.
+        rhs_wo_bias + rhs_bias,
+        rhs_wo_bias,
+        0.0,            // cfm_gain
+        cfm_coeff,
+    );
+}
+*/
+
+fn solve_constraint(constraint_id: u32) {
+    let constraint = &constraints[constraint_id];
+    var solver_vel1 = solver_vels[constraint.solver_vel_a];
+    var solver_vel2 = solver_vels[constraint.solver_vel_b];
+
+    for (var i = 0u; i < constraint.len; i++) {
+        let element = &constraint.elements[i];
+        let dlinvel = dot(element.lin_jac, solver_vel2.linear - solver_vel1.linear);
+        let dangvel =
+            gdot(element.ang_jac_b, solver_vel2.angular) - gdot(element.ang_jac_a, solver_vel1.angular);
+
+        let rhs = dlinvel + dangvel + element.rhs;
+        let total_impulse = clamp(element.impulse + element.inv_lhs * (rhs - element.cfm_gain * element.impulse),
+            element.impulse_bounds[0], element.impulse_bounds[1]);
+        let delta_impulse = total_impulse - element.impulse;
+        element.impulse = total_impulse;
+
+        let lin_impulse = element.lin_jac * delta_impulse;
+
+        solver_vel1.linear += lin_impulse * constraint.im_a;
+        solver_vel1.angular += element.ii_ang_jac_a * delta_impulse;
+        solver_vel2.linear -= lin_impulse * constraint.im_b;
+        solver_vel2.angular -= element.ii_ang_jac_b * delta_impulse;
+    }
+
+    solver_vels[constraint.solver_vel_a] = solver_vel1;
+    solver_vels[constraint.solver_vel_b] = solver_vel2;
+}
+
+#if DIM ==  2
+fn gcross_matrix(r: vec2<f32>) -> vec2<f32> {
+    return vec2(-r.y, r.x);
+}
+#else
+fn gcross_matrix(r: vec3<f32>) -> mat3x3<f32> {
+    return mat3x3(
+        vec3(0.0, r.z, -r.y),
+        vec3(-r.z, 0.0, r.x),
+        vec3(r.y, -r.x, 0.0),
+    );
+}
+#endif
+
+fn smallest_abs_diff_between_angles(a: f32, b: f32) -> f32 {
+    // Select the smallest path among the two angles to reach the target.
+    let s_err = a - b;
+    let sgn = sign(s_err);
+    let s_err_complement = s_err - sgn * Params::TWO_PI;
+    let s_err_is_smallest = abs(s_err) < abs(s_err_complement);
+    return select(s_err_complement, s_err, s_err_is_smallest);
+}
+
+fn pseudo_inv(x: f32) -> f32 {
+    return select(1.0 / x, 0.0, x == 0.0);
+}
+
+#if DIM == 2
+fn gdot(a: f32, b: f32) -> f32 {
+    return a * b;
+}
+#else
+fn gdot(a: vec3<f32>, b: vec3<f32>) -> f32 {
+    return dot(a, b);
+}
+#endif

--- a/crates/wgrapier/src/dynamics/mod.rs
+++ b/crates/wgrapier/src/dynamics/mod.rs
@@ -46,6 +46,7 @@ pub use coloring::{ColoringArgs, WgColoring};
 pub use constraint::{
     GpuTwoBodyConstraint, GpuTwoBodyConstraintBuilder, GpuTwoBodyConstraintInfos, WgConstraint,
 };
+pub use joint::{GpuImpulseJointSet, JointSolverArgs, WgJointSolver};
 pub use mprops_update::WgMpropsUpdate;
 pub use sim_params::{GpuSimParams, WgSimParams};
 pub use solver::{SolverArgs, WgSolver};
@@ -54,6 +55,7 @@ pub use warmstart::{WarmstartArgs, WgWarmstart};
 pub mod body;
 mod coloring;
 mod constraint;
+mod joint;
 mod mprops_update;
 pub mod prefix_sum;
 mod sim_params;

--- a/crates/wgrapier/src_testbed/backend/cpu.rs
+++ b/crates/wgrapier/src_testbed/backend/cpu.rs
@@ -62,7 +62,7 @@ impl CpuBackend {
         #[allow(unused_mut)] // mut not needed in 2D but needed in 3d.
         let mut params = IntegrationParameters::default();
         // NOTE: to keep the comparison fair, use the same friction model as the GPU version
-        //       (the GPU doesn’t implement  twist friction yet).
+        //       (the GPU doesn’t implement twist friction yet).
         #[cfg(feature = "dim3")]
         {
             params.friction_model = FrictionModel::Coulomb;
@@ -87,6 +87,12 @@ impl CpuBackend {
 impl SimulationBackend for CpuBackend {
     fn poses(&self) -> &[GpuSim] {
         &self.poses_cache
+    }
+    fn num_bodies(&self) -> usize {
+        self.poses().len()
+    }
+    fn num_joints(&self) -> usize {
+        self.impulse_joints.len()
     }
 
     async fn step(

--- a/crates/wgrapier/src_testbed/backend/gpu.rs
+++ b/crates/wgrapier/src_testbed/backend/gpu.rs
@@ -36,8 +36,13 @@ impl GpuBackend {
         let pipeline = GpuPhysicsPipeline::from_device(gpu.device())
             .map_err(|e| format!("Failed to compile shaders: {}", e))?;
 
-        let state =
-            GpuPhysicsState::from_rapier(gpu.device(), &phys.bodies, &phys.colliders, use_jacobi);
+        let state = GpuPhysicsState::from_rapier(
+            gpu.device(),
+            &phys.bodies,
+            &phys.colliders,
+            &phys.impulse_joints,
+            use_jacobi,
+        );
         let poses_staging = GpuVector::uninit(
             gpu.device(),
             state.poses().len() as u32,
@@ -64,8 +69,13 @@ impl GpuBackend {
         phys: &SimulationState,
         use_jacobi: bool,
     ) -> Self {
-        let state =
-            GpuPhysicsState::from_rapier(gpu.device(), &phys.bodies, &phys.colliders, use_jacobi);
+        let state = GpuPhysicsState::from_rapier(
+            gpu.device(),
+            &phys.bodies,
+            &phys.colliders,
+            &phys.impulse_joints,
+            use_jacobi,
+        );
         let poses_staging = GpuVector::uninit(
             gpu.device(),
             state.poses().len() as u32,
@@ -101,6 +111,12 @@ impl GpuBackend {
 impl SimulationBackend for GpuBackend {
     fn poses(&self) -> &[GpuSim] {
         &self.poses_cache
+    }
+    fn num_bodies(&self) -> usize {
+        self.poses_cache.len()
+    }
+    fn num_joints(&self) -> usize {
+        self.state.joints().len()
     }
 
     async fn step(

--- a/crates/wgrapier/src_testbed/backend/mod.rs
+++ b/crates/wgrapier/src_testbed/backend/mod.rs
@@ -24,6 +24,8 @@ pub enum BackendType {
 pub trait SimulationBackend {
     /// Get the current poses for rendering
     fn poses(&self) -> &[GpuSim];
+    fn num_bodies(&self) -> usize;
+    fn num_joints(&self) -> usize;
 
     /// Step the simulation
     async fn step(
@@ -55,6 +57,20 @@ impl PhysicsBackend {
         match self {
             PhysicsBackend::Cpu(backend) => backend.poses(),
             PhysicsBackend::Gpu(backend) => backend.poses(),
+        }
+    }
+
+    pub fn num_bodies(&self) -> usize {
+        match self {
+            PhysicsBackend::Cpu(backend) => backend.num_bodies(),
+            PhysicsBackend::Gpu(backend) => backend.num_bodies(),
+        }
+    }
+
+    pub fn num_joints(&self) -> usize {
+        match self {
+            PhysicsBackend::Cpu(backend) => backend.num_joints(),
+            PhysicsBackend::Gpu(backend) => backend.num_joints(),
         }
     }
 }

--- a/crates/wgrapier/src_testbed/ui.rs
+++ b/crates/wgrapier/src_testbed/ui.rs
@@ -135,7 +135,8 @@ pub fn render_ui(
 
             ui.separator();
 
-            ui.label(format!("Number of objects: {}", physics.backend.poses().len()));
+            ui.label(format!("Bodies count: {}", physics.backend.num_bodies()));
+            ui.label(format!("Joints count: {}", physics.backend.num_joints()));
 
             if *backend_type == BackendType::Cpu {
                 ui.label(format!(


### PR DESCRIPTION
This PR adds the support for impulse-based joints. The joint constraints are resolved as part of the TGS solver.
Interestingly, the joints simulated on the GPU tend to be noticeably more stable than on the CPU. My assumption is that the (mandatory) graph coloring that happens for the GPU results in a joint resolution order that results in better stability for PGS. This might be worth exploring for improving the solver on the CPU version.

All the joints from the CPU version of Rapier are supported on the GPU, including joint limits and motors.

The demos can be tested on https://wgmath.rs/demos/wgrapier3d/index.html (select one of the joints demo). Here are a couple of videos captured from the demos (the body count and joints count can are visible in the UI during the first few seconds of each video):

Prismatic joints with limits:

https://github.com/user-attachments/assets/8d069174-5c11-46c9-b333-0f304cce583a

Boxes on a cloth-like material made of spheres attached by spherical joints:

https://github.com/user-attachments/assets/3e680f1c-8b10-41b0-84eb-03e3cd5fb9a6

