### PR TITLE
feat: add collision-detection support for convex polyhedrons

### DIFF
--- a/crates/wgparry/src/bounding_volumes/aabb.rs
+++ b/crates/wgparry/src/bounding_volumes/aabb.rs
@@ -18,7 +18,7 @@ use wgebra::{WgSim2, WgSim3};
 
 #[derive(Shader)]
 #[shader(
-    derive(WgSim3, WgSim2, WgShape),
+    derive(WgSim3, WgSim2),
     src = "./aabb.wgsl",
     src_fn = "substitute_aliases",
     shader_defs = "dim_shader_defs"
@@ -26,7 +26,6 @@ use wgebra::{WgSim2, WgSim3};
 /// GPU shader for computing and manipulating Axis-Aligned Bounding Boxes.
 ///
 /// This shader provides functions for:
-/// - Computing AABBs from shapes.
 /// - AABB overlap testing.
 /// - AABB merging and manipulation.
 pub struct WgAabb;

--- a/crates/wgparry/src/bounding_volumes/aabb.wgsl
+++ b/crates/wgparry/src/bounding_volumes/aabb.wgsl
@@ -5,7 +5,6 @@
 //! non-intersecting pairs.
 //!
 //! Key operations:
-//! - from_shape: Computes tight AABB for any shape type
 //! - check_intersection: Fast AABB-AABB overlap test
 //! - merge: Computes bounding AABB of two AABBs
 
@@ -27,65 +26,6 @@ struct Aabb {
     mins: Vector,
     /// Maximum corner (largest coordinates along each axis).
     maxs: Vector
-}
-
-/// Creates an AABB from a transformed shape.
-fn from_shape(pose: Transform, shape: Shape::Shape) -> Aabb {
-    let ty = Shape::shape_type(shape);
-    if ty == Shape::SHAPE_TYPE_BALL {
-        let ball = Shape::to_ball(shape);
-#if DIM == 2
-        let tra = pose.translation;
-        let rad = ball.radius * pose.scale;
-#else
-        let tra = pose.translation_scale.xyz;
-        let rad = ball.radius * pose.translation_scale.w;
-#endif
-
-        return Aabb(
-            tra - Vector(rad),
-            tra + Vector(rad)
-        );
-    }
-
-    if ty == Shape::SHAPE_TYPE_CUBOID {
-        let cuboid = Shape::to_cuboid(shape);
-        let local_aabb = Aabb(-cuboid.halfExtents, cuboid.halfExtents);
-        return transform(local_aabb, pose);
-    }
-
-    if ty == Shape::SHAPE_TYPE_CAPSULE {
-        let capsule = Shape::to_capsule(shape);
-        let aa = Pose::mulPt(pose, capsule.segment.a);
-        let bb = Pose::mulPt(pose, capsule.segment.b);
-        return Aabb(
-            min(aa, bb) - Vector(capsule.radius),
-            max(aa, bb) + Vector(capsule.radius),
-        );
-    }
-
-#if DIM == 3
-    if ty == Shape::SHAPE_TYPE_CONE {
-        let cone = Shape::to_cone(shape);
-        let local_aabb = Aabb(
-            -vec3(cone.radius, cone.half_height, cone.radius),
-            vec3(cone.radius, cone.half_height, cone.radius),
-        );
-        return transform(local_aabb, pose);
-    }
-
-    if ty == Shape::SHAPE_TYPE_CYLINDER {
-        let cylinder = Shape::to_cylinder(shape);
-        let local_aabb = Aabb(
-            -vec3(cylinder.radius, cylinder.half_height, cylinder.radius),
-            vec3(cylinder.radius, cylinder.half_height, cylinder.radius),
-        );
-        return transform(local_aabb, pose);
-    }
-#endif
-
-    // TODO: not implemented.
-    return Aabb();
 }
 
 /// Are the two AABBs intersecting?

--- a/crates/wgparry/src/broad_phase/brute_force_broad_phase.wgsl
+++ b/crates/wgparry/src/broad_phase/brute_force_broad_phase.wgsl
@@ -55,7 +55,7 @@ fn debug_compute_aabb(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
     if i < arrayLength(&debug_mins) {
         let pose1 = poses[i];
         let shape1 = shapes[i];
-        var aabb1 = Aabb::from_shape(pose1, shape1);
+        var aabb1 = Shape::aabb(pose1, shape1);
         debug_mins[i] = aabb1.mins;
         debug_maxs[i] = aabb1.maxs;
     }
@@ -73,7 +73,7 @@ fn main(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_wo
         let pose1 = poses[i];
         let shape1 = shapes[i];
 
-        var aabb1 = Aabb::from_shape(pose1, shape1);
+        var aabb1 = Shape::aabb(pose1, shape1);
         let prediction = 0.1;
         let dilation = Vector(prediction); // TODO: should be configurable.
         aabb1.mins -= dilation;
@@ -82,7 +82,7 @@ fn main(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_wo
         for (var j = i + 1u; j < num_colliders; j++) {
             let pose2 = poses[j];
             let shape2 = shapes[j];
-            let aabb2 = Aabb::from_shape(pose2, shape2);
+            let aabb2 = Shape::aabb(pose2, shape2);
 
             if Aabb::check_intersection(aabb1, aabb2) {
                 let target_pair_index = atomicAdd(&collision_pairs_len, 1u);

--- a/crates/wgparry/src/broad_phase/lbvh.wgsl
+++ b/crates/wgparry/src/broad_phase/lbvh.wgsl
@@ -271,7 +271,7 @@ fn refit_leaves(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builti
         let leaf_pose = poses[leaf_collider];
         let leaf_shape = shapes[leaf_collider];
 
-        tree[curr_leaf_id].aabb = Aabb::from_shape(leaf_pose, leaf_shape);
+        tree[curr_leaf_id].aabb = Shape::aabb(leaf_pose, leaf_shape);
         tree[curr_leaf_id].left = leaf_collider;
     }
 }
@@ -447,7 +447,7 @@ fn refit(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_w
         let leaf_pose = poses[leaf_collider];
         let leaf_shape = shapes[leaf_collider];
 
-        tree[curr_leaf_id].aabb = Aabb::from_shape(leaf_pose, leaf_shape);
+        tree[curr_leaf_id].aabb = Shape::aabb(leaf_pose, leaf_shape);
         tree[curr_leaf_id].left = leaf_collider;
 
         // Propagate to ancestors.

--- a/crates/wgparry/src/broad_phase/narrow_phase.rs
+++ b/crates/wgparry/src/broad_phase/narrow_phase.rs
@@ -11,7 +11,7 @@
 //! 4. Outputs indexed contacts for the physics solver.
 
 use crate::bounding_volumes::WgAabb;
-use crate::math::GpuSim;
+use crate::math::{GpuSim, Point, Vector};
 use crate::queries::{GpuIndexedContact, WgContact};
 use crate::shapes::{GpuShape, WgShape};
 use crate::{dim_shader_defs, substitute_aliases};
@@ -76,6 +76,8 @@ impl WgNarrowPhase {
         _num_colliders: u32,
         poses: &GpuVector<GpuSim>,
         shapes: &GpuVector<GpuShape>,
+        vertices: &GpuVector<Point<f32>>,
+        indices: &GpuVector<u32>,
         collision_pairs: &GpuVector<[u32; 2]>,
         collision_pairs_len: &GpuScalar<u32>,
         collision_pairs_indirect: &GpuScalar<DispatchIndirectArgs>,
@@ -96,6 +98,8 @@ impl WgNarrowPhase {
                 contacts.buffer(),
                 contacts_len.buffer(),
             ])
+            .bind_at(1, [])
+            .bind_at(2, [(vertices.buffer(), 0), (indices.buffer(), 1)])
             .dispatch_indirect(collision_pairs_indirect.buffer());
 
         KernelDispatch::new(device, pass, &self.init_indirect_args)

--- a/crates/wgparry/src/shapes/convex_polyhedron.rs
+++ b/crates/wgparry/src/shapes/convex_polyhedron.rs
@@ -1,0 +1,21 @@
+//! Convex polyhedron shape.
+
+use crate::bounding_volumes::WgAabb;
+use crate::queries::{WgPolygonalFeature, WgProjection, WgRay};
+use crate::{dim_shader_defs, substitute_aliases};
+use wgcore::Shader;
+use wgebra::{WgSim2, WgSim3};
+
+#[derive(Shader)]
+#[shader(
+    derive(WgSim3, WgSim2, WgRay, WgProjection, WgPolygonalFeature, WgAabb),
+    src = "convex_polyhedron.wgsl",
+    src_fn = "substitute_aliases",
+    shader_defs = "dim_shader_defs"
+)]
+/// GPU shader for the convex polyhedron shape.
+///
+/// The cuboid is defined by a vertex buffer and a triangle index buffer.
+/// Both convex polyhedrons and triangle meshes share the same GPU buffer for storing their
+/// vertices and indices.
+pub struct WgConvexPolyhedron;

--- a/crates/wgparry/src/shapes/convex_polyhedron.wgsl
+++ b/crates/wgparry/src/shapes/convex_polyhedron.wgsl
@@ -1,0 +1,78 @@
+#define_import_path wgparry::convex
+
+#import wgparry::polygonal_feature as Feat
+#import wgparry::bounding_volumes::aabb as Aabb
+
+@group(2) @binding(0)
+var<storage, read> vertices: array<Vector>;
+@group(2) @binding(1)
+var<storage, read> indices: array<u32>;
+
+struct ConvexPolyhedron {
+    // For finding support points.
+    first_vtx_id: u32,
+    end_vtx_id: u32,
+    // For finding support faces.
+    first_face_id: u32,
+    end_face_id: u32,
+}
+
+// TODO: cache the AABB (for example as the first two entries of the shape’s index buffer)
+//       so it doesn’t get recomputed at each frame?
+fn aabb(shape: ConvexPolyhedron) -> Aabb::Aabb {
+    var mins = vertices[shape.first_vtx_id];
+    var maxs = vertices[shape.first_vtx_id];
+
+    for (var i = shape.first_vtx_id; i != shape.end_vtx_id; i++) {
+        mins = min(mins, vertices[i]);
+        maxs = max(maxs, vertices[i]);
+    }
+
+    return Aabb::Aabb(mins, maxs);
+}
+
+fn local_support_point(shape: ConvexPolyhedron, dir: Vector) -> Vector {
+    var best_dot = -1.0e20;
+    var best = Vector();
+    for (var i = shape.first_vtx_id; i != shape.end_vtx_id; i++) {
+        let val = dot(vertices[i], dir);
+        if val > best_dot {
+            best_dot = val;
+            best = vertices[i];
+        }
+    }
+
+    return best;
+}
+
+fn support_face(shape: ConvexPolyhedron, dir: Vector) -> Feat::PolygonalFeature {
+    var result = Feat::PolygonalFeature();
+    var best = vec3(0u);
+    var best_dot = -1.0e20;
+    let base_vid = vec3(shape.first_vtx_id);
+
+    for (var i = shape.first_face_id; i != shape.end_face_id; i += 3) {
+        let vids = base_vid + vec3(indices[i], indices[i + 1], indices[i + 2]);
+        let a = vertices[vids.x];
+        let b = vertices[vids.y];
+        let c = vertices[vids.z];
+        let ab = b - a;
+        let ac = c - a;
+        let n = cross(ab, ac);
+        let n_len = length(n);
+
+        if n_len != 0.0 {
+            let val = dot(n / n_len, dir);
+            if val > best_dot {
+                best_dot = val;
+                best = vids;
+            }
+        }
+    }
+
+    result.vertices[0] = vertices[best.x];
+    result.vertices[1] = vertices[best.y];
+    result.vertices[2] = vertices[best.z];
+    result.num_vertices = 3;
+    return result;
+}

--- a/crates/wgparry/src/shapes/mod.rs
+++ b/crates/wgparry/src/shapes/mod.rs
@@ -5,6 +5,7 @@
 
 mod ball;
 mod capsule;
+mod convex_polyhedron;
 mod cuboid;
 mod segment;
 mod tetrahedron;
@@ -18,6 +19,7 @@ mod shape;
 
 pub use ball::*;
 pub use capsule::*;
+pub use convex_polyhedron::*;
 pub use cuboid::*;
 pub use segment::*;
 pub use shape::*;

--- a/crates/wgrapier/crates/examples3d/all_examples3.rs
+++ b/crates/wgrapier/crates/examples3d/all_examples3.rs
@@ -40,17 +40,17 @@ fn parse_command_line() -> Command {
 #[allow(clippy::type_complexity)]
 pub fn demo_builders() -> Vec<(&'static str, fn() -> SimulationState)> {
     let mut builders: Vec<(_, fn() -> SimulationState)> = vec![
-        // ("Balls", balls3::init_world),
-        // ("Boxes", boxes3::init_world),
-        // ("Boxes & balls", boxes_and_balls3::init_world),
+        ("Balls", balls3::init_world),
+        ("Boxes", boxes3::init_world),
+        ("Boxes & balls", boxes_and_balls3::init_world),
         ("Primitives", primitives3::init_world),
-        // ("Pyramid", pyramid3::init_world),
-        // ("Many pyramids", many_pyramids3::init_world),
-        // ("Keva tower", keva3::init_world),
-        // ("Joints (Spherical)", joint_ball3::init_world),
-        // ("Joints (Fixed)", joint_fixed3::init_world),
-        // ("Joints (Prismatic)", joint_prismatic3::init_world),
-        // ("Joints (Revolute)", joint_revolute3::init_world),
+        ("Pyramid", pyramid3::init_world),
+        ("Many pyramids", many_pyramids3::init_world),
+        ("Keva tower", keva3::init_world),
+        ("Joints (Spherical)", joint_ball3::init_world),
+        ("Joints (Fixed)", joint_fixed3::init_world),
+        ("Joints (Prismatic)", joint_prismatic3::init_world),
+        ("Joints (Revolute)", joint_revolute3::init_world),
     ];
 
     // Lexicographic sort, with stress tests moved at the end of the list.

--- a/crates/wgrapier/crates/examples3d/primitives3.rs
+++ b/crates/wgrapier/crates/examples3d/primitives3.rs
@@ -13,6 +13,8 @@ pub fn init_world() -> SimulationState {
     /*
      * Falling dynamic objects.
      */
+    let mut rng = oorandom::Rand32::new(0);
+
     for j in 0..NY {
         let max_ik = NXZ / 2;
         for i in -max_ik..max_ik {
@@ -23,12 +25,38 @@ pub fn init_world() -> SimulationState {
                 let pos = Vector3::new(x, y, z);
                 let body = bodies.insert(RigidBodyBuilder::dynamic().translation(pos));
 
-                let collider = match j % 5 {
+                let collider = match j % 6 {
                     0 => ColliderBuilder::cylinder(0.5, 0.5),
                     1 => ColliderBuilder::cuboid(0.5, 0.5, 0.5),
                     2 => ColliderBuilder::cone(0.5, 0.5),
-                    3 => ColliderBuilder::capsule_y(0.5, 0.5),
-                    _ => ColliderBuilder::ball(0.5),
+                    3 => ColliderBuilder::capsule_y(0.4, 0.4),
+                    4 => ColliderBuilder::ball(0.5),
+                    _ => {
+                        if i % 2 == 0 || k % 2 == 0 {
+                            continue;
+                        }
+                        // Make a convex polyhedron.
+                        let mut points = Vec::new();
+                        let scale = 2.0;
+                        for _ in 0..10 {
+                            let pt = Point::new(
+                                rng.rand_float() - 0.5,
+                                rng.rand_float() - 0.5,
+                                rng.rand_float() - 0.5,
+                            );
+                            points.push(pt * scale);
+                        }
+
+                        // TODO: align the collider’s local origin to its center-of-mass.
+                        //       wgrapier currently doesn’t support misaligned center-of-masses.
+                        let shape = SharedShape::convex_hull(&points).unwrap();
+                        let mprops = shape.mass_properties(1.0);
+                        points
+                            .iter_mut()
+                            .for_each(|pt| *pt -= mprops.local_com.coords);
+
+                        ColliderBuilder::convex_hull(&points).unwrap()
+                    }
                 };
 
                 colliders.insert_with_parent(collider, body, &mut bodies);

--- a/crates/wgrapier/src/dynamics/body.rs
+++ b/crates/wgrapier/src/dynamics/body.rs
@@ -132,6 +132,7 @@ pub struct GpuBodySet {
     //       is from wgsparkl which has its own way of storing indices.
     pub(crate) shapes_local_vertex_buffers: GpuVector<Point<f32>>,
     pub(crate) shapes_vertex_buffers: GpuVector<Point<f32>>,
+    pub(crate) shapes_index_buffers: GpuVector<u32>,
     pub(crate) shapes_vertex_collider_id: GpuVector<u32>, // NOTE: this is a bit of a hack for wgsparkl
 }
 
@@ -299,6 +300,11 @@ impl GpuBodySet {
                 device,
                 // TODO: init in world-space directly?
                 &shape_buffers.vertices,
+                BufferUsages::STORAGE,
+            ),
+            shapes_index_buffers: GpuVector::init(
+                device,
+                &shape_buffers.indices,
                 BufferUsages::STORAGE,
             ),
             shapes_vertex_collider_id: GpuVector::init(


### PR DESCRIPTION
Based on https://github.com/wgmath/wgmath/pull/12, this adds support for collision-detection with 3D convex polyhedrons.
Convex polyhedrons are special as they cannot be fully stored in the `Shape` pseudo-enum. Instead, we store index ranges in the `Shape` pseudo-enum, and keep its vertex and index buffers separate.

Convex polyhedrons have beed added to the `primitives` examples (they are rendered with a red color) of the 3D testbed, showing that they can interact with all other shape types (including other convex polyhedrons).

https://github.com/user-attachments/assets/0e2a1f2d-9ff9-4471-a6c6-c40109fd01d8

⚠️ This PR is part of a series of PR for bringing wgrapier to feature-parity with rapier (the cpu implementation). Note that checking out this branch alone might not compile without the other PRs merged. CI failure is expected for this PR.