### PR TITLE
feat: support 2D capsules, polylines, and convex polygons

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ solutions (like CUDA).
 ⚠️ All these libraries are still under heavy development and might be lacking some important features. Contributions
 are welcome!
 
+## Web Performance Notes
+
+When running on the Web, best results are achieved with chrome-based browsers (including Edge).
+
+Note that:
+
+- We found WebGPU to be 10x slower on linux (tested on Ubuntu) compared to Windows or MacOS.
+- We found Firefox (nightly) to be 10x slower than Chrome on all platforms (including MacOS/Windows).
+- Keep in mind that some browsers don’t have WebGPU enabled by default and/or has an experimental
+  WebGPU implementation (like safari) that might not work.
+
 ----
 
 **See the readme of each individual crate (on the `crates` directory) for additional details.**

--- a/crates/wgparry/crates/wgparry2d/Cargo.toml
+++ b/crates/wgparry/crates/wgparry2d/Cargo.toml
@@ -32,6 +32,7 @@ parry2d = { workspace = true }
 
 wgcore = { version = "0.2", path = "../../../wgcore", features = ["derive"] }
 wgebra = { version = "0.2", path = "../../../wgebra" }
+bvh = "0.12"
 
 [dev-dependencies]
 nalgebra = { version = "0.34", features = ["rand"] }

--- a/crates/wgparry/src/bounding_volumes/aabb.rs
+++ b/crates/wgparry/src/bounding_volumes/aabb.rs
@@ -11,7 +11,6 @@
 //! - **Fast overlap test**: Just compare min/max coordinates (6 comparisons in 3D).
 //! - **Fast to compute**: For most shapes, AABB computation is very efficient.
 
-use crate::shapes::WgShape;
 use crate::{dim_shader_defs, substitute_aliases};
 use wgcore::{test_shader_compilation, Shader};
 use wgebra::{WgSim2, WgSim3};

--- a/crates/wgparry/src/broad_phase/lbvh.rs
+++ b/crates/wgparry/src/broad_phase/lbvh.rs
@@ -1,5 +1,5 @@
 use crate::bounding_volumes::WgAabb;
-use crate::math::{GpuSim, Point, Vector};
+use crate::math::{GpuSim, Point};
 use crate::shapes::{GpuShape, WgShape};
 use crate::utils::{RadixSort, RadixSortWorkspace};
 use crate::{dim_shader_defs, substitute_aliases};
@@ -209,7 +209,6 @@ impl Lbvh {
         colliders_len: u32,
         poses: &GpuVector<GpuSim>,
         vertex_buffers: &GpuVector<Point<f32>>,
-        index_buffers: &GpuVector<u32>,
         shapes: &GpuVector<GpuShape>,
         num_shapes: &GpuScalar<u32>,
     ) {

--- a/crates/wgparry/src/broad_phase/lbvh.rs
+++ b/crates/wgparry/src/broad_phase/lbvh.rs
@@ -359,8 +359,7 @@ mod test {
         let gpu_poses_data: Vec<GpuSim> = poses.iter().map(|p| (*p).into()).collect();
         let shapes: Vec<_> = vec![GpuShape::ball(0.5); LEN as usize];
 
-        let gpu_vertices = GpuVector::encase(gpu.device(), &[], storage);
-        let gpu_indices = GpuVector::init(gpu.device(), &[], storage);
+        let gpu_vertices = GpuVector::encase(gpu.device(), [], storage);
         let gpu_poses = GpuVector::init(gpu.device(), &gpu_poses_data, storage);
         let gpu_shapes = GpuVector::init(gpu.device(), &shapes, storage);
         let gpu_num_shapes = GpuScalar::init(
@@ -383,7 +382,6 @@ mod test {
             LEN,
             &gpu_poses,
             &gpu_vertices,
-            &gpu_indices,
             &gpu_shapes,
             &gpu_num_shapes,
         );

--- a/crates/wgparry/src/broad_phase/narrow_phase.rs
+++ b/crates/wgparry/src/broad_phase/narrow_phase.rs
@@ -11,9 +11,9 @@
 //! 4. Outputs indexed contacts for the physics solver.
 
 use crate::bounding_volumes::WgAabb;
-use crate::math::{GpuSim, Point, Vector};
+use crate::math::{GpuSim, Point};
 use crate::queries::{GpuIndexedContact, WgContact};
-use crate::shapes::{GpuShape, WgShape, WgTriMesh};
+use crate::shapes::{GpuShape, WgCapsule, WgPolyline, WgShape, WgTriMesh};
 use crate::{dim_shader_defs, substitute_aliases};
 use wgcore::indirect::{DispatchIndirectArgs, WgIndirect};
 use wgcore::kernel::KernelDispatch;
@@ -24,7 +24,9 @@ use wgpu::{ComputePass, ComputePipeline, Device};
 
 #[derive(Shader)]
 #[shader(
-    derive(WgSim3, WgSim2, WgShape, WgAabb, WgContact, WgIndirect, WgTriMesh),
+    derive(
+        WgSim3, WgSim2, WgShape, WgAabb, WgContact, WgIndirect, WgTriMesh, WgPolyline, WgCapsule
+    ),
     src = "./narrow_phase.wgsl",
     src_fn = "substitute_aliases",
     shader_defs = "dim_shader_defs",

--- a/crates/wgparry/src/broad_phase/narrow_phase.wgsl
+++ b/crates/wgparry/src/broad_phase/narrow_phase.wgsl
@@ -23,6 +23,8 @@
 #import wgparry::bounding_volumes::aabb as Aabb
 #import wgcore::indirect as Indirect
 #import wgparry::trimesh as TriMesh
+#import wgparry::polyline as Polyline
+#import wgparry::capsule as Capsule
 
 #if DIM == 2
     #import wgebra::sim2 as Pose;
@@ -140,6 +142,23 @@ fn main(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_wo
             return;
         }
 
+        if !checked && shape_ty1 == Shape::SHAPE_TYPE_POLYLINE {
+            let polyline = Shape::to_polyline(shapes[pair.x]);
+            let convex = shapes[pair.y];
+            polyline_convex(pose12, polyline, convex, prediction, pair);
+            return;
+        }
+
+        if !checked && shape_ty2 == Shape::SHAPE_TYPE_POLYLINE {
+            let convex = shapes[pair.x];
+            let polyline = Shape::to_polyline(shapes[pair.y]);
+            // NOTE: pair indices are  flipped.
+            polyline_convex(Pose::inv(pose12), polyline, convex, prediction, pair.yx);
+            // Early-exit since `polyline_convex` is special and writes directly to the output
+            // `contacst` buffer.
+            return;
+        }
+
         if manifold.len > 0 && manifold.points_a[0].dist < prediction {
             let target_contact_index = atomicAdd(&contacts_len, 1u);
             contacts[target_contact_index] = Contact::IndexedManifold(manifold, pair);
@@ -188,6 +207,59 @@ fn trimesh_convex(pose12: Transform, mesh: TriMesh::TriMesh, convex: Shape::Shap
             curr = idx.exit_index;
         } else {
             let aabb = TriMesh::bvh_node_aabb(mesh, curr);
+            if Aabb::check_intersection(test_aabb, aabb) {
+                curr = idx.entry_index;
+            } else {
+                curr = idx.exit_index;
+            }
+        }
+    }
+}
+
+
+// Collision-detection between a polyline and a convex shape.
+// While this is not a very clean place to have this function, it’s our best (only?) option if
+// we want to output the result incrementally into the `contacts` storage buffer. this could be
+// much cleaner if we could pass storage buffers as arguments to function but we can’t with WGSL :/
+fn polyline_convex(pose12: Transform, mesh: Polyline::Polyline, convex: Shape::Shape, prediction: f32, pair: vec2<u32>) {
+    let sub2 = Shape::pfm_subshape(convex);
+    if !sub2.valid {
+        // Collisions with non-PFM shapes is not supported.
+        return;
+    }
+
+    // Get the convex shape’s AABB in the trimesh’s local space, and enlarge with the prediction.
+    let thickness = 0.4;
+    var test_aabb = Shape::aabb(pose12, convex);
+    test_aabb.mins -= Vector(prediction + thickness);
+    test_aabb.maxs += Vector(prediction + thickness);
+
+    if !Aabb::check_intersection(test_aabb, mesh.root_aabb) {
+        // No collision possible.
+        return;
+    }
+
+    var curr = 0u;
+
+    while curr < mesh.bvh_node_len {
+        let idx = Polyline::bvh_node_idx(mesh, curr);
+        if idx.entry_index == 0xffffffffu {
+            // This is a leaf.
+            let segment = Polyline::segment(mesh, idx.shape_index);
+            let capsule = Capsule::Capsule(segment, thickness); // The segment is seen as a 0-sized capsule
+            let sub1 = Shape::pfm_subshape(Shape::from_capsule(capsule));
+            // TODO PERF: add special-cases for pairs that can be handled more efficiently than with GJK/EPA.
+            let manifold = Contact::pfm_pfm(pose12, sub1.shape, sub1.thickness, sub2.shape, sub2.thickness, prediction);
+
+            if manifold.len > 0u && manifold.points_a[0].dist < prediction {
+                let target_contact_index = atomicAdd(&contacts_len, 1u);
+                contacts[target_contact_index] = Contact::IndexedManifold(manifold, pair);
+            }
+
+            // Continue traversal.
+            curr = idx.exit_index;
+        } else {
+            let aabb = Polyline::bvh_node_aabb(mesh, curr);
             if Aabb::check_intersection(test_aabb, aabb) {
                 curr = idx.entry_index;
             } else {

--- a/crates/wgparry/src/queries/contact.rs
+++ b/crates/wgparry/src/queries/contact.rs
@@ -14,12 +14,15 @@
 use super::{WgPolygonalFeature, WgSat};
 use crate::math::Vector;
 use crate::queries::gjk::{WgCsoPoint, WgEpa, WgGjk, WgVoronoiSimplex};
-use crate::shapes::{WgBall, WgCone, WgCuboid, WgCylinder, WgShape};
+use crate::shapes::{WgBall, WgCuboid, WgShape};
 use crate::{dim_shader_defs, substitute_aliases};
 use encase::ShaderType;
 use na::Vector2;
 use wgcore::Shader;
 use wgebra::{WgSim2, WgSim3};
+
+#[cfg(feature = "dim3")]
+use crate::shapes::{WgCone, WgCylinder};
 
 #[cfg(feature = "dim2")]
 const MAX_MANIFOLD_POINTS: usize = 2;
@@ -88,23 +91,45 @@ pub struct GpuIndexedContact {
 }
 
 #[derive(Shader)]
-#[shader(
-    derive(
-        WgBall,
-        WgCuboid,
-        WgCylinder,
-        WgShape,
-        WgCone,
-        WgSim2,
-        WgSim3,
-        WgSat,
-        WgPolygonalFeature,
-        WgContactManifold,
-        WgContactPfmPfm,
-    ),
-    src = "contact.wgsl",
-    src_fn = "substitute_aliases",
-    shader_defs = "dim_shader_defs"
+#[cfg_attr(
+    feature = "dim2",
+    shader(
+        derive(
+            WgBall,
+            WgCuboid,
+            WgShape,
+            WgSim2,
+            WgSim3,
+            WgSat,
+            WgPolygonalFeature,
+            WgContactManifold,
+            WgContactPfmPfm,
+        ),
+        src = "contact.wgsl",
+        src_fn = "substitute_aliases",
+        shader_defs = "dim_shader_defs"
+    )
+)]
+#[cfg_attr(
+    feature = "dim3",
+    shader(
+        derive(
+            WgBall,
+            WgCuboid,
+            WgShape,
+            WgSim2,
+            WgSim3,
+            WgSat,
+            WgPolygonalFeature,
+            WgContactManifold,
+            WgContactPfmPfm,
+            WgCylinder,
+            WgCone
+        ),
+        src = "contact.wgsl",
+        src_fn = "substitute_aliases",
+        shader_defs = "dim_shader_defs"
+    )
 )]
 /// GPU shader for contact generation between shapes.
 ///
@@ -145,6 +170,11 @@ pub struct WgContactManifold;
     src_fn = "substitute_aliases",
     shader_defs = "dim_shader_defs"
 )]
+/// Kernel for contact manifold calculation between two "Polygonal Feature Maps".
+///
+/// A Polygonal Feature Map is similar to the concept of Support Mappings, except that
+/// instead associating an extremal point to a vector, it associates an extremal polygonal
+/// face to the direction.
 pub struct WgContactPfmPfm;
 
 wgcore::test_shader_compilation!(WgContact, wgcore, crate::dim_shader_defs());

--- a/crates/wgparry/src/queries/contact.wgsl
+++ b/crates/wgparry/src/queries/contact.wgsl
@@ -73,7 +73,7 @@ fn ball_ball(pose12: Transform, ball1: Ball::Ball, ball2: Ball::Ball) -> Manifol
     return Manifold::single_point(point1, distance - sum_radius, normal1);
 }
 
-fn convex_ball(pose12: Transform, cuboid1: Shape::Shape, ball2: Ball::Ball) -> Manifold::ContactManifold {
+fn convex_ball(pose12: Transform, shape1: Shape::Shape, ball2: Ball::Ball) -> Manifold::ContactManifold {
 #if DIM == 2
     let center2_1 = pose12.translation;
     var y = vec2(0.0, 1.0);
@@ -82,7 +82,7 @@ fn convex_ball(pose12: Transform, cuboid1: Shape::Shape, ball2: Ball::Ball) -> M
     var y = vec3(0.0, 1.0, 0.0);
 #endif
 
-    let proj = Shape::projectLocalPointOnBoundary(cuboid1, center2_1);
+    let proj = Shape::projectLocalPointOnBoundary(shape1, center2_1);
     let proj_vec = center2_1 - proj.point;
     var dist = length(proj_vec);
     var normal1 = select(y, proj_vec / dist, dist != 0.0);
@@ -95,17 +95,17 @@ fn convex_ball(pose12: Transform, cuboid1: Shape::Shape, ball2: Ball::Ball) -> M
     return Manifold::single_point(proj.point, dist - ball2.radius, normal1);
 }
 
-fn ball_convex(pose12: Transform, ball1: Ball::Ball, cuboid2: Shape::Shape) -> Manifold::ContactManifold {
+fn ball_convex(pose12: Transform, ball1: Ball::Ball, shape2: Shape::Shape) -> Manifold::ContactManifold {
     let pose21 = Pose::inv(pose12);
-    var result = convex_ball(pose21, cuboid2, ball1);
+    var result = convex_ball(pose21, shape2, ball1);
     let normal1 = -Pose::mulUnitVec(pose12, result.normal_a);
     result.points_a[0].pt = normal1 * ball1.radius;
     result.normal_a = normal1;
     return result;
 }
 
-fn pfm_pfm(pose12: Transform, cuboid1: Shape::Shape, thickness1: f32, cuboid2: Shape::Shape, thickness2: f32, prediction: f32) -> Manifold::ContactManifold {
-    return PfmPfm::contact_manifold_pfm_pfm(pose12, cuboid1, thickness1, cuboid2, thickness2, prediction);
+fn pfm_pfm(pose12: Transform, shape1: Shape::Shape, thickness1: f32, shape2: Shape::Shape, thickness2: f32, prediction: f32) -> Manifold::ContactManifold {
+    return PfmPfm::contact_manifold_pfm_pfm(pose12, shape1, thickness1, shape2, thickness2, prediction);
 }
 
 fn cuboid_cuboid(pose12: Transform, cuboid1: Cuboid::Cuboid, cuboid2: Cuboid::Cuboid, prediction: f32) -> Manifold::ContactManifold {

--- a/crates/wgparry/src/queries/contact_pfm_pfm.wgsl
+++ b/crates/wgparry/src/queries/contact_pfm_pfm.wgsl
@@ -23,12 +23,22 @@ fn contact_support_map_support_map(
     g2: Shape::Shape,
     prediction: f32,
 ) -> Gjk::GjkResult {
+    #if DIM == 2
+    let x_axis = vec2(1.0, 0.0);
+    #else
+    let x_axis = vec3(1.0, 0.0, 0.0);
+    #endif
+
+#if DIM == 2
+    var dir = pose12.translation;
+#else
     var dir = pose12.translation_scale.xyz;
+#endif
     var dir_len_sq = dot(dir, dir);
     if dir_len_sq > CsoPoint::FLT_EPS * CsoPoint::FLT_EPS {
         dir /= sqrt(dir_len_sq);
     } else {
-        dir = vec3(1.0, 0.0, 0.0);
+        dir = x_axis;
     }
 
     let cso_point = Gjk::cso_point_from_shapes(pose12, g1, g2, dir);
@@ -46,7 +56,7 @@ fn contact_support_map_support_map(
     }
 
     // Everything failed
-    return Gjk::gjk_result_no_intersection(vec3(1.0, 0.0, 0.0));
+    return Gjk::gjk_result_no_intersection(x_axis);
 }
 
 fn contact_manifold_pfm_pfm(
@@ -103,7 +113,7 @@ fn contact_manifold_pfm_pfm(
             manifold.normal_a = local_n1;
             return manifold;
         }
-        default: { /* No collitions. */ }
+        default: { /* No collisions. */ }
     }
 
     return ContactManifold::ContactManifold();

--- a/crates/wgparry/src/queries/gjk/epa2.wgsl
+++ b/crates/wgparry/src/queries/gjk/epa2.wgsl
@@ -1,0 +1,435 @@
+#define_import_path wgparry::epa
+
+#import wgebra::sim2 as Pose
+#import wgparry::gjk::gjk as Gjk
+#import wgparry::gjk::cso_point as CsoPoint
+#import wgparry::gjk::voronoi_simplex as VoronoiSimplex
+#import wgparry::triangle as Triangle
+#import wgparry::projection as Proj
+#import wgparry::shape as Shape
+
+
+// TODO: find the ideal values.
+const MAX_VERTICES_LEN: u32 = 32;
+const MAX_FACES_LEN: u32 = 32;
+const MAX_HEAP_LEN: u32 = 32;
+
+var<private> vertices: array<CsoPoint::CsoPoint, MAX_VERTICES_LEN>;
+var<private> vertices_len: u32;
+var<private> faces: array<Face, MAX_FACES_LEN>;
+var<private> faces_len: u32;
+var<private> heap: array<FaceId, MAX_HEAP_LEN>; // TODO: BinaryHeap<FaceId>
+var<private> heap_len: u32;
+
+fn heap_best_index() -> u32 {
+    var best_id = 0u;
+
+    for (var i = 0u; i < heap_len; i++) {
+        if heap[i].neg_dist > heap[best_id].neg_dist {
+            best_id = i;
+        }
+    }
+
+    return best_id;
+}
+
+fn heap_peek() -> FaceId {
+    return heap[heap_best_index()];
+}
+
+fn heap_pop() -> FaceId {
+    // TODO PERF: implement an actual priority queue.
+    let i = heap_best_index();
+    let result = heap[i];
+
+    if heap_len != 0u {
+        heap_len -= 1u;
+        heap[i] = heap[heap_len]; // Swap-remove.
+    } else {
+        /* unreachable */
+    }
+
+    return result;
+}
+
+// If it runs out of memory, returns `false`.
+fn heap_push(elt: FaceId) -> bool {
+    if heap_len != MAX_HEAP_LEN {
+        heap[heap_len] = elt;
+        heap_len += 1;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+struct FaceId {
+    id: u32,
+    neg_dist: f32,
+}
+
+struct OptionFaceId {
+    face_id: FaceId,
+    valid: bool,
+}
+
+fn face_id_new(id: u32, neg_dist: f32) -> OptionFaceId {
+    if neg_dist > CsoPoint::EPS_TOL {
+        return OptionFaceId(FaceId(), false);
+    } else {
+        return OptionFaceId(FaceId(id, neg_dist), true);
+    }
+}
+
+struct Face {
+    pts: array<u32, 2>,
+    normal: Vector,
+    proj: vec2<f32>,
+    bcoords: vec2<f32>,
+    deleted: bool,
+}
+
+struct FaceWithProj {
+    face: Face,
+    proj_inside: bool,
+}
+
+fn face_new(pts: array<u32, 2>) -> FaceWithProj {
+    let proj = project_origin(vertices[pts[0]].point, vertices[pts[1]].point);
+    if proj.valid {
+        return FaceWithProj(face_new_with_proj(proj.point, proj.bcoords, pts), true);
+    } else {
+        return FaceWithProj(face_new_with_proj(vec2(), vec2(), pts), false);
+    }
+}
+
+fn face_new_with_proj(
+    proj: vec2<f32>,
+    bcoords: vec2<f32>,
+    pts: array<u32, 2>,
+) -> Face {
+    let n = ccw_face_normal(
+        vertices[pts[0]].point,
+        vertices[pts[1]].point,
+    );
+    return Face(pts, n, proj, bcoords, all(n == vec2()));
+}
+
+fn face_closest_points(face: Face) -> array<vec2<f32>, 2> {
+    return array(
+        vertices[face.pts[0]].orig_a * face.bcoords[0]
+            + vertices[face.pts[1]].orig_a * face.bcoords[1],
+        vertices[face.pts[0]].orig_b * face.bcoords[0]
+            + vertices[face.pts[1]].orig_b * face.bcoords[1],
+    );
+}
+
+struct EpaResult {
+    pt_a: vec2<f32>,
+    pt_b: vec2<f32>,
+    normal: vec2<f32>,
+    valid: bool,
+}
+
+fn none() -> EpaResult {
+    return EpaResult(vec2(), vec2(), vec2(), false);
+}
+
+fn closest_points(
+    pose12: Transform,
+    g1: Shape::Shape,
+    g2: Shape::Shape,
+    simplex: VoronoiSimplex::VoronoiSimplex,
+) -> EpaResult
+{
+    let _eps = CsoPoint::FLT_EPS;
+    let _eps_tol = _eps * 100.0;
+
+    /*
+     * Reset buffers.
+     */
+   vertices_len = 0u;
+   faces_len = 0u;
+   heap_len = 0u;
+
+    /*
+     * Initialization.
+     */
+    for (var i = 0u; i < simplex.dim + 1u; i++) {
+        vertices[vertices_len] = simplex.vertices[i];
+        vertices_len += 1u;
+    }
+
+    if simplex.dim == 0 {
+        const MAX_ITERS: u32 = 100; // If there is no convergence, just use whatever direction was extracted so far
+
+        // The contact is vertex-vertex.
+        // We need to determine a valid normal that lies
+        // on both vertices' normal cone.
+        var n = vec2(0.0, 1.0);
+
+        // First, find a vector on the first vertex tangent cone.
+        let orig1 = vertices[0].orig_a;
+        for (var k = 0u; k < MAX_ITERS; k++) {
+            let supp1 = Shape::local_support_point(g1, n);
+            var tangent = supp1 - orig1;
+            let tangent_len = length(tangent);
+
+            if tangent_len > _eps_tol {
+                tangent /= tangent_len;
+                if dot(n, tangent) < _eps_tol {
+                    break;
+                }
+
+                n = vec2(-tangent.y, tangent.x);
+            } else {
+                break;
+            }
+        }
+
+        // Second, ensure the direction lies on the second vertex's tangent cone.
+        let orig2 = vertices[0].orig_b;
+        for (var k = 0u; k < MAX_ITERS; k++) {
+            let supp2 = Shape::support_point(g2, pose12, -n);
+            var tangent = supp2 - orig2;
+            let tangent_len = length(tangent);
+
+            if tangent_len > _eps_tol {
+                tangent /= tangent_len;
+                if dot(-n, tangent) < _eps_tol {
+                    break;
+                }
+
+                n = vec2(-tangent.y, tangent.x);
+            } else {
+                break;
+            }
+        }
+
+        return EpaResult(vec2(), vec2(), n, true);
+    } else if simplex.dim == 2 {
+        let dp1 = vertices[1].point - vertices[0].point;
+        let dp2 = vertices[2].point - vertices[0].point;
+
+        if Triangle::perp(dp1, dp2) < 0.0 {
+            let vtx1 = vertices[1];
+            vertices[1] = vertices[2];
+            vertices[2] = vtx1;
+        }
+
+        let pts1 = array(0u, 1);
+        let pts2 = array(1u, 2);
+        let pts3 = array(2u, 0);
+
+        let face1 = face_new(pts1);
+        let face2 = face_new(pts2);
+        let face3 = face_new(pts3);
+
+        faces[0] = face1.face;
+        faces[1] = face2.face;
+        faces[2] = face3.face;
+        faces_len = 3;
+
+        if face1.proj_inside {
+            let dist1 = dot(faces[0].normal, vertices[0].point);
+            let face_id = face_id_new(0, -dist1);
+
+            if !face_id.valid {
+                return none();
+            }
+
+            heap_push(face_id.face_id);
+        }
+
+        if face2.proj_inside {
+            let dist2 = dot(faces[1].normal, vertices[1].point);
+            let face_id = face_id_new(1, -dist2);
+
+            if !face_id.valid {
+                return none();
+            }
+
+            heap_push(face_id.face_id);
+        }
+
+        if face3.proj_inside {
+            let dist3 = dot(faces[2].normal, vertices[2].point);
+            let face_id = face_id_new(2, -dist3);
+
+            if !face_id.valid {
+                return none();
+            }
+
+            heap_push(face_id.face_id);
+        }
+
+        if !(face1.proj_inside || face2.proj_inside || face3.proj_inside) {
+            // Related issues:
+            // https://github.com/dimforge/parry/issues/253
+            // https://github.com/dimforge/parry/issues/246
+            return none();
+        }
+    } else {
+        let pts1 = array(0u, 1);
+        let pts2 = array(1u, 0);
+
+        faces[0] = face_new_with_proj(vec2(), vec2(1.0, 0.0), pts1);
+        faces[1] = face_new_with_proj(vec2(), vec2(1.0, 0.0), pts2);
+        faces_len = 2;
+
+        let dist1 = dot(faces[0].normal, vertices[0].point);
+        let dist2 = dot(faces[1].normal, vertices[1].point);
+        let fid1 = face_id_new(0u, dist1);
+        let fid2 = face_id_new(1u, dist2);
+
+        if !fid1.valid {
+            return none();
+        }
+        if !fid2.valid {
+            return none();
+        }
+
+        heap_push(fid1.face_id);
+        heap_push(fid2.face_id);
+    }
+
+    if heap_len == 0 {
+        return none();
+    }
+
+    var niter = 0u;
+    var max_dist = 1.0e20;
+    var best_face_id = heap_peek();
+    var old_dist = 0.0;
+
+    /*
+     * Run the expansion.
+     */
+    while heap_len > 0u {
+        let face_id = heap_pop();
+        // Create new faces.
+        let face = faces[face_id.id];
+
+        if face.deleted {
+            continue;
+        }
+
+        let cso_point = Gjk::cso_point_from_shapes(pose12, g1, g2, face.normal);
+        let support_point_id = vertices_len;
+
+        if vertices_len != MAX_VERTICES_LEN {
+            vertices[vertices_len] = cso_point;
+            vertices_len += 1;
+        } else {
+            // We ran out of memory.
+            return none();
+        }
+
+        let candidate_max_dist = dot(cso_point.point, face.normal);
+
+        if candidate_max_dist < max_dist {
+            best_face_id = face_id;
+            max_dist = candidate_max_dist;
+        }
+
+        let curr_dist = -face_id.neg_dist;
+
+        if max_dist - curr_dist < _eps_tol ||
+            // Accept the intersection as the algorithm is stuck and no new points will be found
+            // This happens because of numerical stability issue
+            (abs(curr_dist - old_dist) < _eps && candidate_max_dist < max_dist)
+        {
+            let best_face = faces[best_face_id.id];
+            let points = face_closest_points(best_face);
+            return EpaResult(points[0], points[1], best_face.normal, true);
+        }
+
+        old_dist = curr_dist;
+
+        let pts1 = array(face.pts[0], support_point_id);
+        let pts2 = array(support_point_id, face.pts[1]);
+
+        let new_faces = array(
+            face_new(pts1),
+            face_new(pts2),
+        );
+
+        // TODO: unroll
+        for (var fi = 0u; fi < 2u; fi++) {
+            let f = new_faces[fi];
+            if f.proj_inside {
+                let dist = dot(f.face.normal, f.face.proj);
+                if dist < curr_dist {
+                    // TODO: if we reach this point, there were issues due to
+                    // numerical errors.
+                    let cpts = face_closest_points(f.face);
+                    return EpaResult(cpts[0], cpts[1], f.face.normal, true);
+                }
+
+                if !f.face.deleted {
+                    let new_fid = face_id_new(faces_len, -dist);
+                    if !new_fid.valid {
+                        return none();
+                    }
+
+                    if !heap_push(new_fid.face_id) {
+                        return none();
+                    }
+                }
+            }
+
+            if faces_len != MAX_FACES_LEN {
+                faces[faces_len] = f.face;
+                faces_len += 1;
+            } else {
+                return none();
+            }
+        }
+
+        niter += 1;
+        if niter > 100 {
+            // if we reached this point, our algorithm didn't converge to what precision we wanted.
+            // still return an intersection point, as it's probably close enough.
+            break;
+        }
+    }
+
+    let best_face = faces[best_face_id.id];
+    let points = face_closest_points(best_face);
+    return EpaResult(points[0], points[1], best_face.normal, true);
+}
+
+struct ProjectOriginResult {
+    point: vec2<f32>,
+    bcoords: vec2<f32>,
+    valid: bool,
+}
+
+fn project_origin(a: vec2<f32>, b: vec2<f32>) -> ProjectOriginResult {
+    let ab = b - a;
+    let ap = -a;
+    let ab_ap = dot(ab, ap);
+    let sqnab = dot(ab, ab);
+
+    if sqnab == 0.0 {
+        return ProjectOriginResult(vec2(), vec2(), false);
+    }
+
+    if ab_ap < -CsoPoint::EPS_TOL || ab_ap > sqnab + CsoPoint::EPS_TOL {
+        // Voronoï region of vertex 'a' or 'b'.
+        return ProjectOriginResult(vec2(), vec2(), false);
+    } else {
+        // Voronoï region of the segment interior.
+        let position_on_segment = ab_ap / sqnab;
+        let res = a + ab * position_on_segment;
+
+        return ProjectOriginResult(res, vec2(1.0 - position_on_segment, position_on_segment), true);
+    }
+}
+
+fn ccw_face_normal(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {
+    let ab = b - a;
+    let res = vec2(ab.y, -ab.x);
+    let res_length = length(res);
+    return select(vec2(), res / res_length, res_length > CsoPoint::FLT_EPS);
+}

--- a/crates/wgparry/src/queries/gjk/gjk.wgsl
+++ b/crates/wgparry/src/queries/gjk/gjk.wgsl
@@ -143,7 +143,11 @@ fn closest_points(
         }
     }
 
+#if DIM == 2
+    return gjk_result_no_intersection(Vector(1.0, 0.0));
+#else
     return gjk_result_no_intersection(Vector(1.0, 0.0, 0.0));
+#endif
 }
 
 fn result(simplex: VoronoiSimplex::VoronoiSimplex, prev: bool) -> array<Vector, 2> {

--- a/crates/wgparry/src/queries/gjk/mod.rs
+++ b/crates/wgparry/src/queries/gjk/mod.rs
@@ -1,7 +1,10 @@
 use crate::queries::WgProjection;
-use crate::shapes::{WgSegment, WgShape, WgTetrahedron, WgTriangle};
+use crate::shapes::{WgSegment, WgShape, WgTriangle};
 use crate::{dim_shader_defs, substitute_aliases};
 use wgcore::Shader;
+
+#[cfg(feature = "dim3")]
+use crate::shapes::WgTetrahedron;
 
 #[derive(Shader)]
 #[shader(
@@ -21,20 +24,44 @@ pub struct WgCsoPoint;
 pub struct WgGjk;
 
 #[derive(Shader)]
-#[shader(
-    derive(WgCsoPoint, WgSegment, WgTriangle, WgTetrahedron, WgProjection),
-    src = "voronoi_simplex3.wgsl",
-    shader_defs = "dim_shader_defs",
-    src_fn = "substitute_aliases"
+#[cfg_attr(
+    feature = "dim2",
+    shader(
+        derive(WgCsoPoint, WgSegment, WgTriangle, WgProjection),
+        src = "voronoi_simplex2.wgsl",
+        shader_defs = "dim_shader_defs",
+        src_fn = "substitute_aliases"
+    )
+)]
+#[cfg_attr(
+    feature = "dim3",
+    shader(
+        derive(WgCsoPoint, WgSegment, WgTriangle, WgTetrahedron, WgProjection),
+        src = "voronoi_simplex3.wgsl",
+        shader_defs = "dim_shader_defs",
+        src_fn = "substitute_aliases"
+    )
 )]
 pub struct WgVoronoiSimplex;
 
 #[derive(Shader)]
-#[shader(
-    derive(WgCsoPoint, WgVoronoiSimplex, WgShape, WgGjk),
-    src = "epa3.wgsl",
-    shader_defs = "dim_shader_defs",
-    src_fn = "substitute_aliases"
+#[cfg_attr(
+    feature = "dim2",
+    shader(
+        derive(WgCsoPoint, WgVoronoiSimplex, WgShape, WgGjk),
+        src = "epa2.wgsl",
+        shader_defs = "dim_shader_defs",
+        src_fn = "substitute_aliases"
+    )
+)]
+#[cfg_attr(
+    feature = "dim3",
+    shader(
+        derive(WgCsoPoint, WgVoronoiSimplex, WgShape, WgGjk),
+        src = "epa3.wgsl",
+        shader_defs = "dim_shader_defs",
+        src_fn = "substitute_aliases"
+    )
 )]
 pub struct WgEpa;
 

--- a/crates/wgparry/src/queries/gjk/voronoi_simplex2.wgsl
+++ b/crates/wgparry/src/queries/gjk/voronoi_simplex2.wgsl
@@ -1,0 +1,166 @@
+#define_import_path wgparry::gjk::voronoi_simplex
+
+#import wgparry::gjk::cso_point as CsoPoint
+#import wgparry::segment as Segment
+#import wgparry::triangle as Triangle
+#import wgparry::projection as Proj
+
+/// A simplex of dimension up to 2 using Voronoï regions for computing point projections.
+struct VoronoiSimplex {
+    prev_vertices: array<u32, 3>,
+    prev_proj: vec2<f32>,
+    prev_dim: u32,
+
+    vertices: array<CsoPoint::CsoPoint, 3>,
+    proj: vec2<f32>,
+    dim: u32,
+}
+
+struct SimplexProjectionResult {
+    simplex: VoronoiSimplex,
+    point: vec2<f32>,
+}
+
+fn init(pt: CsoPoint::CsoPoint) -> VoronoiSimplex {
+    let origin = CsoPoint::origin();
+    let prev_vertices = array(0u, 1u, 2u);
+    let prev_proj = vec2(0.0, 0.0);
+    let prev_dim = 0u;
+    let vertices = array(pt, origin, origin);
+    let proj = vec2(0.0, 0.0);
+    let dim = 0u;
+    return VoronoiSimplex(prev_vertices, prev_proj, prev_dim, vertices, proj, dim);
+}
+
+// TODO: all these free functions should be methods (not supported by wgsl).
+
+fn reset(s: VoronoiSimplex, pt: CsoPoint::CsoPoint) -> VoronoiSimplex {
+    return VoronoiSimplex(s.prev_vertices, s.prev_proj, 0u, array(pt, pt, pt), s.proj, 0u);
+}
+
+
+/// Add a point to this simplex.
+fn add_point(s: VoronoiSimplex, pt: CsoPoint::CsoPoint) -> VoronoiSimplex {
+    var result = s;
+    result.prev_dim = s.dim;
+    result.prev_proj = s.proj;
+    result.prev_vertices = array(0, 1, 2);
+
+    for (var i = 0u; i < s.dim + 1u; i++) {
+        let dpt = s.vertices[i].point - pt.point;
+        if dot(dpt, dpt) < CsoPoint::EPS_TOL {
+            return s;
+        }
+    }
+
+    result.dim += 1;
+    result.vertices[result.dim] = pt;
+    return result;
+}
+
+/// Projects the origin on the boundary of this simplex and reduces `s` the smallest subsimplex containing the origin.
+///
+/// Returns the result of the projection or Point::origin() if the origin lies inside of the simplex.
+/// The state of the simplex before projection is saved, and can be retrieved using the methods prefixed
+/// by `prev_`.
+fn project_origin_and_reduce(s_: VoronoiSimplex) -> SimplexProjectionResult {
+    var s = s_;
+
+    switch s.dim {
+        case 0: {
+            s.proj[0] = 1.0;
+            return SimplexProjectionResult(s, s.vertices[0].point);
+        }
+        case 1: {
+            let seg = Segment::Segment(s.vertices[0u].point, s.vertices[1u].point);
+            let proj = Segment::project_local_point_and_get_location(seg, vec2(), true);
+
+            switch proj.feature_type {
+                case Proj::FEATURE_VERTEX: {
+                    if proj.id == 0u {
+                        s.proj[0] = 1.0;
+                        s.dim = 0;
+                    } else {
+                        // Swap 0, 1
+                        let tmp = s.vertices[0];
+                        s.vertices[0] = s.vertices[1];
+                        s.vertices[1] = tmp;
+                        let tmp_prev = s.prev_vertices[0];
+                        s.prev_vertices[0] = s.prev_vertices[1];
+                        s.prev_vertices[1] = tmp_prev;
+
+                        s.proj[0] = 1.0;
+                        s.dim = 0u;
+                    }
+                }
+                case Proj::FEATURE_EDGE: {
+                    s.proj[0] = proj.bcoords[0];
+                    s.proj[1] = proj.bcoords[1];
+                }
+                default: { /* unreachable */ }
+            }
+
+            return SimplexProjectionResult(s, proj.point);
+        }
+        default: {
+            // case 2
+            let tri = Triangle::Triangle(
+                s.vertices[0].point,
+                s.vertices[1].point,
+                s.vertices[2].point,
+            );
+            var proj = Triangle::project_local_point_and_get_location(tri, vec2(), true);
+
+            switch proj.feature_type {
+                case Proj::FEATURE_VERTEX: {
+                    let i = proj.id;
+
+                    // Swap 0, i
+                    let tmp = s.vertices[0];
+                    s.vertices[0] = s.vertices[i];
+                    s.vertices[i] = tmp;
+                    let tmp_prev = s.prev_vertices[0];
+                    s.prev_vertices[0] = s.prev_vertices[i];
+                    s.prev_vertices[i] = tmp_prev;
+
+                    s.proj[0] = 1.0;
+                    s.dim = 0u;
+                }
+                case Proj::FEATURE_EDGE: {
+                    if proj.id == 0u {
+                        s.proj[0] = proj.bcoords[0];
+                        s.proj[1] = proj.bcoords[1];
+                        s.dim = 1;
+                    } else if proj.id == 1u {
+                        // Swap 0, 2
+                        let tmp = s.vertices[0];
+                        s.vertices[0] = s.vertices[2];
+                        s.vertices[2] = tmp;
+                        let tmp_prev = s.prev_vertices[0];
+                        s.prev_vertices[0] = s.prev_vertices[2];
+                        s.prev_vertices[2] = tmp_prev;
+
+                        s.proj[0] = proj.bcoords[1];
+                        s.proj[1] = proj.bcoords[0];
+                        s.dim = 1u;
+                    } else {
+                        // Swap 1, 2
+                        let tmp = s.vertices[1];
+                        s.vertices[1] = s.vertices[2];
+                        s.vertices[2] = tmp;
+                        let tmp_prev = s.prev_vertices[1];
+                        s.prev_vertices[1] = s.prev_vertices[2];
+                        s.prev_vertices[2] = tmp_prev;
+
+                        s.proj[0] = proj.bcoords[0];
+                        s.proj[1] = proj.bcoords[1];
+                        s.dim = 1u;
+                    }
+                }
+                default: { /* unreachable */ }
+            }
+
+            return SimplexProjectionResult(s, proj.point);
+        }
+    }
+}

--- a/crates/wgparry/src/queries/gjk/voronoi_simplex3.wgsl
+++ b/crates/wgparry/src/queries/gjk/voronoi_simplex3.wgsl
@@ -32,8 +32,6 @@ fn init(pt: CsoPoint::CsoPoint) -> VoronoiSimplex {
     let dim = 0u;
     return VoronoiSimplex(prev_vertices, prev_proj, prev_dim, vertices, proj, dim);
 }
-// TODO: all these free functions should be methods (not supported by wgsl).
-
 
 fn reset(s: VoronoiSimplex, pt: CsoPoint::CsoPoint) -> VoronoiSimplex {
     return VoronoiSimplex(s.prev_vertices, s.prev_proj, 0u, array(pt, pt, pt, pt), s.proj, 0u);

--- a/crates/wgparry/src/queries/projection.wgsl
+++ b/crates/wgparry/src/queries/projection.wgsl
@@ -6,7 +6,7 @@
 
 #define_import_path wgparry::projection
 
-const EPSILON: vec3<f32> = vec3(1.1920929E-7);
+const EPSILON: Vector = Vector(1.1920929E-7);
 
 /// The result of a point projection operation.
 ///
@@ -23,7 +23,7 @@ struct ProjectionResult {
 
 struct ProjectionWithLocation {
     point: Vector,
-    bcoords: Vector,
+    bcoords: vec3<f32>,
     // 0: vertex, 1: edge, 2: face
     feature_type: u32,
     id: u32,
@@ -31,7 +31,7 @@ struct ProjectionWithLocation {
 }
 
 fn vertex(pt: Vector, id: u32, inside: bool) -> ProjectionWithLocation {
-    return ProjectionWithLocation(pt, Vector(), FEATURE_VERTEX, id, inside);
+    return ProjectionWithLocation(pt, vec3(), FEATURE_VERTEX, id, inside);
 }
 
 fn edge(pt: Vector, bcoords: vec2<f32>, id: u32, inside: bool) -> ProjectionWithLocation {
@@ -43,7 +43,7 @@ fn face(pt: Vector, bcoords: vec3<f32>, id: u32, inside: bool) -> ProjectionWith
 }
 
 fn solid(pt: Vector) -> ProjectionWithLocation {
-    return ProjectionWithLocation(pt, Vector(), FEATURE_SOLID, 0, true);
+    return ProjectionWithLocation(pt, vec3(), FEATURE_SOLID, 0, true);
 }
 
 #if DIM == 3
@@ -87,7 +87,7 @@ const FEATURE_FACE: u32 = 2;
 const FEATURE_SOLID: u32 = 3;
 
 // TODO: move that to its own utility file
-fn relative_eq(a: vec3<f32>, b: vec3<f32>) -> bool {
+fn relative_eq(a: Vector, b: Vector) -> bool {
     let abs_diff = abs(a - b);
 
     // For when the numbers are really close together

--- a/crates/wgparry/src/shapes/capsule.wgsl
+++ b/crates/wgparry/src/shapes/capsule.wgsl
@@ -28,6 +28,7 @@ struct Capsule {
     radius: f32,
 }
 
+#if DIM == 3
 /// Computes an orthonormal basis from a single 3D vector.
 ///
 /// Given a normalized vector v, this function computes two orthogonal vectors
@@ -53,6 +54,7 @@ fn orthonormal_basis3(v: vec3<f32>) -> array<vec3<f32>, 2> {
         vec3(b, sign + v.y * v.y * a, -v.y),
     );
 }
+#endif
 
 /// Finds an arbitrary vector orthogonal to the given vector.
 ///
@@ -158,7 +160,12 @@ fn local_support_point(shape: Capsule, dir: Vector) -> Vector {
     }
 
     let dir_len = length(dir);
-    let normal = select(Vector(0.0, 1.0, 0.0), dir / dir_len, dir_len != 0.0);
+    #if DIM == 2
+    let y = Vector(0.0, 1.0);
+    #else
+    let y = Vector(0.0, 1.0, 0.0);
+    #endif
+    let normal = select(y, dir / dir_len, dir_len != 0.0);
     return endpoint + normal * shape.radius;
 }
 

--- a/crates/wgparry/src/shapes/convex_polyhedron.wgsl
+++ b/crates/wgparry/src/shapes/convex_polyhedron.wgsl
@@ -8,7 +8,7 @@ struct ConvexPolyhedron {
     // For finding support points.
     first_vtx_id: u32,
     end_vtx_id: u32,
-    // For finding support faces.
+    // For finding support faces (3D only).
     first_face_id: u32,
     end_face_id: u32,
 }
@@ -41,6 +41,37 @@ fn local_support_point(shape: ConvexPolyhedron, dir: Vector) -> Vector {
     return best;
 }
 
+#if DIM == 2
+fn support_face(shape: ConvexPolyhedron, dir: Vector) -> Feat::PolygonalFeature {
+    var result = Feat::PolygonalFeature();
+    var best = vec2(0u);
+    var best_dot = -1.0e20;
+    let num_vertices = shape.end_vtx_id - shape.first_vtx_id;
+
+    for (var i = 0u; i < num_vertices; i += 1u) {
+        let j = (i + 1u) % num_vertices;
+        let a = VtxIdx::vertices[shape.first_vtx_id + i];
+        let b = VtxIdx::vertices[shape.first_vtx_id + j];
+        let ab = b - a;
+        // CounterClockWise 2D normal.
+        let n = vec2(ab.y, -ab.x);
+        let n_len = length(n);
+
+        if n_len != 0.0 {
+            let val = dot(n / n_len, dir);
+            if val > best_dot {
+                best_dot = val;
+                best = vec2(i, j);
+            }
+        }
+    }
+
+    result.vertices[0] = VtxIdx::vertices[shape.first_vtx_id + best.x];
+    result.vertices[1] = VtxIdx::vertices[shape.first_vtx_id + best.y];
+    result.num_vertices = 2;
+    return result;
+}
+#else
 fn support_face(shape: ConvexPolyhedron, dir: Vector) -> Feat::PolygonalFeature {
     var result = Feat::PolygonalFeature();
     var best = vec3(0u);
@@ -72,3 +103,4 @@ fn support_face(shape: ConvexPolyhedron, dir: Vector) -> Feat::PolygonalFeature 
     result.num_vertices = 3;
     return result;
 }
+#endif

--- a/crates/wgparry/src/shapes/cuboid.wgsl
+++ b/crates/wgparry/src/shapes/cuboid.wgsl
@@ -104,8 +104,8 @@ fn support_face(box: Cuboid, axis: Vector) -> Feat::PolygonalFeature {
         let sign = select(-1.0, 1.0, axis[0] > 0.0);
         return Feat::PolygonalFeature(
             array(
-                vec2(he.x * sign, -he.y),
                 vec2(he.x * sign, he.y),
+                vec2(he.x * sign, -he.y),
             ),
             2,
         );

--- a/crates/wgparry/src/shapes/mod.rs
+++ b/crates/wgparry/src/shapes/mod.rs
@@ -7,14 +7,17 @@ mod ball;
 mod capsule;
 mod convex_polyhedron;
 mod cuboid;
+mod polyline;
 mod segment;
-mod tetrahedron;
 mod triangle;
 
 #[cfg(feature = "dim3")]
 mod cone;
 #[cfg(feature = "dim3")]
 mod cylinder;
+#[cfg(feature = "dim3")]
+mod tetrahedron;
+
 mod shape;
 mod trimesh;
 mod vtx_idx;
@@ -23,9 +26,9 @@ pub use ball::*;
 pub use capsule::*;
 pub use convex_polyhedron::*;
 pub use cuboid::*;
+pub use polyline::*;
 pub use segment::*;
 pub use shape::*;
-pub use tetrahedron::*;
 pub use triangle::*;
 pub use trimesh::*;
 pub use vtx_idx::*;
@@ -34,3 +37,5 @@ pub use vtx_idx::*;
 pub use cone::*;
 #[cfg(feature = "dim3")]
 pub use cylinder::*;
+#[cfg(feature = "dim3")]
+pub use tetrahedron::*;

--- a/crates/wgparry/src/shapes/polyline.rs
+++ b/crates/wgparry/src/shapes/polyline.rs
@@ -1,0 +1,32 @@
+//! Triangle mesh shape.
+
+use crate::bounding_volumes::WgAabb;
+use crate::queries::{WgPolygonalFeature, WgProjection, WgRay};
+use crate::shapes::{WgConvexPolyhedron, WgSegment, WgVtxIdx};
+use crate::{dim_shader_defs, substitute_aliases};
+use wgcore::Shader;
+use wgebra::{WgSim2, WgSim3};
+
+#[derive(Shader)]
+#[shader(
+    derive(
+        WgSim3,
+        WgSim2,
+        WgRay,
+        WgProjection,
+        WgPolygonalFeature,
+        WgAabb,
+        WgSegment,
+        WgConvexPolyhedron,
+        WgVtxIdx,
+    ),
+    src = "polyline.wgsl",
+    src_fn = "substitute_aliases",
+    shader_defs = "dim_shader_defs"
+)]
+/// GPU shader for the polyline shape.
+///
+/// The polyline is defined by a BVH, vertex buffer and a triangle index buffer.
+/// The BVH is stored as part of the vertex and index buffer, before the actual vertices and indices.
+/// It stores two vectors and one index per AABB.
+pub struct WgPolyline;

--- a/crates/wgparry/src/shapes/polyline.wgsl
+++ b/crates/wgparry/src/shapes/polyline.wgsl
@@ -1,20 +1,20 @@
-#define_import_path wgparry::trimesh
+#define_import_path wgparry::polyline
 
 #import wgparry::polygonal_feature as Feat
 #import wgparry::bounding_volumes::aabb as Aabb
-#import wgparry::triangle as Triangle
+#import wgparry::segment as Segment
 #import wgparry::vtx_idx as VtxIdx
 
-/// A triangle mesh.
+/// A polyline
 ///
-/// The mesh’s vertex and index buffer are organized is a way that the vertex
-/// buffer contains the BVH first, and then then the triangle vertices.
+/// The polyline’s vertex and index buffer are organized is a way that the vertex
+/// buffer contains the BVH first, and then then the segment vertices.
 /// Similarly, its index buffer contains the BVH topology information fisrt, and then
-/// the triangle vertices.
+/// the segment vertices.
 ///
 /// The BVH topology follows https://docs.rs/bvh/0.12.0/bvh/flat_bvh/struct.FlatNode.html
 /// So each BVH node implies 3 entries in the index buffer, and 2 entries in the vertex buffer.
-struct TriMesh {
+struct Polyline {
     /// Index of the root AABB in the vertex buffer.
     bvh_vtx_root_id: u32,
     /// The root AABB left-child index.
@@ -31,27 +31,26 @@ struct BvhIdx {
 }
 
 // Simply return the root aabb.
-fn aabb(shape: TriMesh) -> Aabb::Aabb {
+fn aabb(shape: Polyline) -> Aabb::Aabb {
     return shape.root_aabb;
 }
 
-fn bvh_node_aabb(mesh: TriMesh, node_id: u32) -> Aabb::Aabb {
+fn bvh_node_aabb(mesh: Polyline, node_id: u32) -> Aabb::Aabb {
     let vid = mesh.bvh_vtx_root_id + node_id * 2u; // Multiply by 2 since there are two values per AABB (min/max).
     return Aabb::Aabb(VtxIdx::vertices[vid], VtxIdx::vertices[vid + 1]);
 }
 
-fn bvh_node_idx(mesh: TriMesh, node_id: u32) -> BvhIdx {
+fn bvh_node_idx(mesh: Polyline, node_id: u32) -> BvhIdx {
     let base_id = mesh.bvh_idx_root_id + node_id * 3u;
     return BvhIdx(VtxIdx::indices[base_id], VtxIdx::indices[base_id + 1], VtxIdx::indices[base_id + 2]);
 }
 
-fn triangle(mesh: TriMesh, tri_id: u32) -> Triangle::Triangle {
-    let base_id = mesh.bvh_idx_root_id + mesh.bvh_node_len * 3u + tri_id * 3u;
+fn segment(mesh: Polyline, seg_id: u32) -> Segment::Segment {
+    let base_id = mesh.bvh_idx_root_id + mesh.bvh_node_len * 3u + seg_id * 2u;
     let base_vid = mesh.bvh_vtx_root_id + mesh.bvh_node_len * 2u;
     let a = VtxIdx::vertices[base_vid + VtxIdx::indices[base_id]];
     let b = VtxIdx::vertices[base_vid + VtxIdx::indices[base_id + 1]];
-    let c = VtxIdx::vertices[base_vid + VtxIdx::indices[base_id + 2]];
-    return Triangle::Triangle(a, b, c);
+    return Segment::Segment(a, b);
 }
 
 // TODO PERF: tree traversal is implemented directly in `narrow_phase.wgsl` so it can redispatch

--- a/crates/wgparry/src/shapes/shape.wgsl
+++ b/crates/wgparry/src/shapes/shape.wgsl
@@ -28,6 +28,7 @@
 #import wgparry::polygonal_feature as Feat
 #import wgparry::convex as Convex;
 #import wgparry::trimesh as TriMesh;
+#import wgparry::polyline as Polyline;
 #import wgparry::triangle as Tri;
 #import wgparry::bounding_volumes::aabb as Aabb;
 
@@ -42,7 +43,7 @@ const SHAPE_TYPE_CYLINDER: u32 = 4;
 const SHAPE_TYPE_POLYLINE: u32 = 5;
 const SHAPE_TYPE_TRIMESH: u32 = 6;
 const SHAPE_TYPE_CONVEX_POLY: u32 = 7;
-// TODO: since this shape type is only for trimeshesh, it doesn’t implement all the
+// TODO: since this shape type is only for trimesh, it doesn’t implement all the
 //       operations it could if it were a standalone shape.
 const SHAPE_TYPE_TRIANGLE: u32 = 8;
 
@@ -87,16 +88,28 @@ fn to_triangle(shape: Shape) -> Tri::Triangle {
     //     vec4(a.x, a.y, a.z, shape_type)
     //     vec4(b.x, b.y, b.z, _)
     //     vec4(c.x, c.y, c.z, _)
+    #if DIM == 2
+    return Tri::Triangle(shape.a.xy, shape.b.xy, shape.c.xy);
+    #else
     return Tri::Triangle(shape.a.xyz, shape.b.xyz, shape.c.xyz);
+    #endif
 }
 
 fn from_triangle(tri: Tri::Triangle) -> Shape {
     let tag = bitcast<f32>(SHAPE_TYPE_TRIANGLE);
+    #if DIM == 2
+    return Shape(
+        vec4(tri.a, 0.0, tag),
+        vec4(tri.b, 0.0, 0.0),
+        vec4(tri.c, 0.0, 0.0)
+    );
+    #else
     return Shape(
         vec4(tri.a, tag),
         vec4(tri.b, 0.0),
         vec4(tri.c, 0.0)
     );
+    #endif
 }
 
 fn to_capsule(shape: Shape) -> Cap::Capsule {
@@ -111,8 +124,13 @@ fn to_capsule(shape: Shape) -> Cap::Capsule {
 }
 
 fn from_capsule(cap: Cap::Capsule) -> Shape {
+#if DIM == 2
+    let a = vec4(cap.segment.a, 0.0, bitcast<f32>(SHAPE_TYPE_CAPSULE));
+    let b = vec4(cap.segment.b, 0.0, cap.radius);
+#else
     let a = vec4(cap.segment.a, bitcast<f32>(SHAPE_TYPE_CAPSULE));
     let b = vec4(cap.segment.b, cap.radius);
+#endif
     return Shape(a, b, vec4());
 }
 
@@ -162,8 +180,28 @@ fn to_trimesh(shape: Shape) -> TriMesh::TriMesh {
     let bvh_vtx_root_id = bitcast<u32>(shape.a.x);
     let bvh_idx_root_id = bitcast<u32>(shape.a.y);
     let first_tri_id = bitcast<u32>(shape.a.z);
+    #if DIM == 2
+    let root_aabb = Aabb::Aabb(shape.b.xy, shape.c.xy);
+    #else
     let root_aabb = Aabb::Aabb(shape.b.xyz, shape.c.xyz);
+    #endif
     return TriMesh::TriMesh(bvh_vtx_root_id, bvh_idx_root_id, first_tri_id, root_aabb);
+}
+
+fn to_polyline(shape: Shape) -> Polyline::Polyline {
+    // Polyline layout:
+    //     vec4(bvh_vtx_root_id, bvh_idx_root_id, first_seg_id, shape_type)
+    //     vec4(root_aabb.mins, _)
+    //     vec4(root_aabb.maxs, _)
+    let bvh_vtx_root_id = bitcast<u32>(shape.a.x);
+    let bvh_idx_root_id = bitcast<u32>(shape.a.y);
+    let first_seg_id = bitcast<u32>(shape.a.z);
+    #if DIM == 2
+    let root_aabb = Aabb::Aabb(shape.b.xy, shape.c.xy);
+    #else
+    let root_aabb = Aabb::Aabb(shape.b.xyz, shape.c.xyz);
+    #endif
+    return Polyline::Polyline(bvh_vtx_root_id, bvh_idx_root_id, first_seg_id, root_aabb);
 }
 
 /*
@@ -315,7 +353,7 @@ fn support_face(shape: Shape, dir: Vector) -> Feat::PolygonalFeature {
     if ty == SHAPE_TYPE_CUBOID {
         return Cub::support_face(to_cuboid(shape), dir);
     }
-    if ty == SHAPE_TYPE_CUBOID {
+    if ty == SHAPE_TYPE_TRIANGLE {
         return Tri::support_face(to_triangle(shape), dir);
     }
     if ty == SHAPE_TYPE_CAPSULE {
@@ -431,6 +469,12 @@ fn aabb(pose: Transform, shape: Shape) -> Aabb::Aabb {
     if ty == SHAPE_TYPE_TRIMESH {
         let trimesh = to_trimesh(shape);
         let local_aabb = TriMesh::aabb(trimesh);
+        return Aabb::transform(local_aabb, pose);
+    }
+
+    if ty == SHAPE_TYPE_POLYLINE {
+        let polyline = to_polyline(shape);
+        let local_aabb = Polyline::aabb(polyline);
         return Aabb::transform(local_aabb, pose);
     }
 

--- a/crates/wgparry/src/shapes/vtx_idx.rs
+++ b/crates/wgparry/src/shapes/vtx_idx.rs
@@ -1,12 +1,8 @@
 //! Buffer bindings for all the complex shapes requiring an index and vertex buffer
 //! (trimesh, convex polyhedrons, etc.)
 
-use crate::bounding_volumes::WgAabb;
-use crate::queries::{WgPolygonalFeature, WgProjection, WgRay};
-use crate::shapes::{WgConvexPolyhedron, WgTriangle};
 use crate::{dim_shader_defs, substitute_aliases};
 use wgcore::Shader;
-use wgebra::{WgSim2, WgSim3};
 
 #[derive(Shader)]
 #[shader(

--- a/crates/wgrapier/README.md
+++ b/crates/wgrapier/README.md
@@ -55,6 +55,17 @@ cargo run --release --bin all_examples2 --target wasm32-unknown-unknown
 cargo run --release --bin all_examples3 --target wasm32-unknown-unknown
 ```
 
+## Web Performance Notes
+
+When running on the Web, best results are achieved with chrome-based browsers (including Edge).
+
+Note that:
+
+- We found WebGPU to be 10x slower on linux (tested on Ubuntu) compared to Windows or MacOS.
+- We found Firefox (nightly) to be 10x slower than Chrome on all platforms (including MacOS/Windows).
+- Keep in mind that some browsers don’t have WebGPU enabled by default and/or has an experimental
+  WebGPU implementation (like safari) that might not work.
+
 ## Resources
 
 - [wgmath repository](https://github.com/wgmath/wgmath)

--- a/crates/wgrapier/crates/examples2d/Cargo.toml
+++ b/crates/wgrapier/crates/examples2d/Cargo.toml
@@ -13,7 +13,7 @@ oorandom = "11"
 wgrapier_testbed2d = { path = "../wgrapier_testbed2d" }
 wgrapier2d = { path = "../wgrapier2d" }
 rapier2d = "0.30.0"
-kiss3d = "0.37.1"
+kiss3d = "0.37.2"
 
 [[bin]]
 name = "all_examples2"

--- a/crates/wgrapier/crates/examples2d/all_examples2.rs
+++ b/crates/wgrapier/crates/examples2d/all_examples2.rs
@@ -9,6 +9,8 @@ mod boxes_and_balls2;
 mod joint_ball2;
 mod joint_fixed2;
 mod joint_prismatic2;
+mod polyline2;
+mod primitives2;
 mod pyramid2;
 
 fn demo_name_from_command_line() -> Option<String> {
@@ -43,6 +45,8 @@ pub async fn main() {
         ("Boxes", boxes2::init_world),
         ("Boxes & balls", boxes_and_balls2::init_world),
         ("Pyramid", pyramid2::init_world),
+        ("Primitives", primitives2::init_world),
+        ("Polyline", polyline2::init_world),
         ("Joints (spherical)", joint_ball2::init_world),
         ("Joints (prismatic)", joint_prismatic2::init_world),
         ("Joints (fixed)", joint_fixed2::init_world),

--- a/crates/wgrapier/crates/examples2d/polyline2.rs
+++ b/crates/wgrapier/crates/examples2d/polyline2.rs
@@ -1,0 +1,94 @@
+use rapier2d::prelude::*;
+use wgrapier_testbed2d::SimulationState;
+
+pub fn init_world() -> SimulationState {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let _multibody_joints = MultibodyJointSet::new();
+
+    /*
+     * Ground
+     */
+    let ground_size = 200.0;
+    let nsubdivs = 40;
+    let step_size = ground_size / (nsubdivs as f32);
+    let mut points = Vec::new();
+
+    points.push(point![-ground_size / 2.0, 240.0]);
+    for i in 1..nsubdivs - 1 {
+        let x = -ground_size / 2.0 + i as f32 * step_size;
+        let y = (i as f32 / nsubdivs as f32 * 10.0).cos() * 20.0;
+        points.push(point![x, y]);
+    }
+    points.push(point![ground_size / 2.0, 240.0]);
+
+    let rigid_body = RigidBodyBuilder::fixed();
+    let handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::polyline(points, None);
+    colliders.insert_with_parent(collider, handle, &mut bodies);
+
+    /*
+     * Create the cubes
+     */
+    let num = 100;
+    let rad = 0.5;
+
+    let shift = rad * 2.0 + 0.4;
+    let centerx = shift * (num as f32) / 2.0;
+    let centery = shift / 2.0;
+    let mut rng = oorandom::Rand32::new(0);
+
+    for i in 0..num {
+        for j in 0usize..num * 3 {
+            let x = i as f32 * shift - centerx + (j % 2) as f32 * 0.2;
+            let y = j as f32 * shift + centery + 20.0;
+
+            // Build the rigid body.
+            let rigid_body = RigidBodyBuilder::dynamic().translation(vector![x, y]);
+            let handle = bodies.insert(rigid_body);
+            let collider = match j % 4 {
+                0 => ColliderBuilder::cuboid(rad, rad),
+                1 => ColliderBuilder::capsule_y(rad, rad),
+                2 => {
+                    if i % 2 == 0 {
+                        continue;
+                    }
+
+                    // Make a convex polygon.
+                    let mut points = Vec::new();
+                    let scale = 2.0;
+                    for _ in 0..10 {
+                        let pt = Point::new(rng.rand_float() - 0.5, rng.rand_float() - 0.5);
+                        points.push(pt * scale);
+                    }
+
+                    // TODO: align the collider’s local origin to its center-of-mass.
+                    //       wgrapier currently doesn’t support misaligned center-of-masses.
+                    let shape = SharedShape::convex_hull(&points).unwrap();
+                    let mprops = shape.mass_properties(1.0);
+                    points
+                        .iter_mut()
+                        .for_each(|pt| *pt -= mprops.local_com.coords);
+
+                    ColliderBuilder::convex_hull(&points).unwrap()
+                }
+                _ => ColliderBuilder::ball(rad),
+            };
+            colliders.insert_with_parent(collider, handle, &mut bodies);
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    SimulationState {
+        bodies,
+        colliders,
+        impulse_joints,
+    }
+    // testbed.look_at(point![0.0, 50.0], 10.0);
+}

--- a/crates/wgrapier/crates/examples2d/primitives2.rs
+++ b/crates/wgrapier/crates/examples2d/primitives2.rs
@@ -1,0 +1,97 @@
+use rapier2d::prelude::*;
+use wgrapier_testbed2d::SimulationState;
+
+pub fn init_world() -> SimulationState {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let _multibody_joints = MultibodyJointSet::new();
+
+    /*
+     * Ground
+     */
+    let ground_size = 150.0;
+
+    let rigid_body = RigidBodyBuilder::fixed();
+    let handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::cuboid(ground_size, 1.5);
+    colliders.insert_with_parent(collider, handle, &mut bodies);
+
+    let rigid_body = RigidBodyBuilder::fixed()
+        .rotation(std::f32::consts::FRAC_PI_2)
+        .translation(vector![ground_size, ground_size * 1.2]);
+    let handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::cuboid(ground_size * 1.2, 1.5);
+    colliders.insert_with_parent(collider, handle, &mut bodies);
+
+    let rigid_body = RigidBodyBuilder::fixed()
+        .rotation(std::f32::consts::FRAC_PI_2)
+        .translation(vector![-ground_size, ground_size * 1.2]);
+    let handle = bodies.insert(rigid_body);
+    let collider = ColliderBuilder::cuboid(ground_size * 1.2, 1.5);
+    colliders.insert_with_parent(collider, handle, &mut bodies);
+
+    /*
+     * Create the cubes
+     */
+    let num = 124;
+    let rad = 0.5;
+
+    let shift = rad * 2.0 + 0.4;
+    let centerx = shift * (num as f32) / 2.0;
+    let centery = shift / 2.0;
+    let mut rng = oorandom::Rand32::new(0);
+
+    for i in 0..num {
+        for j in 0usize..num * 4 {
+            let x = i as f32 * shift - centerx + (j % 2) as f32 * 0.2;
+            let y = j as f32 * shift + centery + 20.0;
+
+            // Build the rigid body.
+            let rigid_body = RigidBodyBuilder::dynamic().translation(vector![x, y]);
+            let handle = bodies.insert(rigid_body);
+            let collider = match j % 4 {
+                0 => ColliderBuilder::cuboid(rad, rad),
+                1 => ColliderBuilder::capsule_y(rad, rad),
+                2 => {
+                    if i % 2 == 0 {
+                        continue;
+                    }
+
+                    // Make a convex polygon.
+                    let mut points = Vec::new();
+                    let scale = 2.0;
+                    for _ in 0..10 {
+                        let pt = Point::new(rng.rand_float() - 0.5, rng.rand_float() - 0.5);
+                        points.push(pt * scale);
+                    }
+
+                    // TODO: align the collider’s local origin to its center-of-mass.
+                    //       wgrapier currently doesn’t support misaligned center-of-masses.
+                    let shape = SharedShape::convex_hull(&points).unwrap();
+                    let mprops = shape.mass_properties(1.0);
+                    points
+                        .iter_mut()
+                        .for_each(|pt| *pt -= mprops.local_com.coords);
+
+                    ColliderBuilder::convex_hull(&points).unwrap()
+                }
+                _ => ColliderBuilder::ball(rad),
+            };
+            colliders.insert_with_parent(collider, handle, &mut bodies);
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    SimulationState {
+        bodies,
+        colliders,
+        impulse_joints,
+    }
+    // testbed.look_at(point![0.0, 50.0], 10.0);
+}

--- a/crates/wgrapier/crates/examples3d/Cargo.toml
+++ b/crates/wgrapier/crates/examples3d/Cargo.toml
@@ -13,7 +13,7 @@ oorandom = "11"
 wgrapier_testbed3d = { path = "../wgrapier_testbed3d" }
 wgrapier3d = { path = "../wgrapier3d" }
 rapier3d = "0.30.0"
-kiss3d = "0.37.1"
+kiss3d = "0.37.2"
 
 [[bin]]
 name = "all_examples3"

--- a/crates/wgrapier/crates/wgrapier2d/Cargo.toml
+++ b/crates/wgrapier/crates/wgrapier2d/Cargo.toml
@@ -41,4 +41,4 @@ nalgebra = { version = "0.34", features = ["rand", "glam029"] }
 futures-test = "0.3"
 serial_test = "3"
 approx = "0.5"
-kiss3d = "0.37.1"
+kiss3d = "0.37.2"

--- a/crates/wgrapier/crates/wgrapier3d/Cargo.toml
+++ b/crates/wgrapier/crates/wgrapier3d/Cargo.toml
@@ -41,4 +41,4 @@ nalgebra = { version = "0.34", features = ["rand", "glam029"] }
 futures-test = "0.3"
 serial_test = "3"
 approx = "0.5"
-kiss3d = "0.37.1"
+kiss3d = "0.37.2"

--- a/crates/wgrapier/crates/wgrapier_testbed2d/Cargo.toml
+++ b/crates/wgrapier/crates/wgrapier_testbed2d/Cargo.toml
@@ -35,7 +35,7 @@ wgparry2d = { version = "0.2", path = "../../../wgparry/crates/wgparry2d" }
 wgrapier2d = { version = "0.2", path = "../wgrapier2d" }
 rapier2d = { version = "0.30", features = ["simd-stable"] }
 num-traits = "0.2"
-kiss3d = { version = "0.37.1", features = ["egui"] }
+kiss3d = { version = "0.37.2", features = ["egui"] }
 web-time = "1"
 
 [dev-dependencies]

--- a/crates/wgrapier/crates/wgrapier_testbed3d/Cargo.toml
+++ b/crates/wgrapier/crates/wgrapier_testbed3d/Cargo.toml
@@ -35,7 +35,7 @@ wgparry3d = { version = "0.2", path = "../../../wgparry/crates/wgparry3d" }
 wgrapier3d = { version = "0.2", path = "../wgrapier3d" }
 rapier3d = { version = "0.30", features = ["simd-stable"] }
 num-traits = "0.2"
-kiss3d = { version = "0.37.1", features = ["egui"] }
+kiss3d = { version = "0.37.2", features = ["egui"] }
 web-time = "1"
 
 [dev-dependencies]

--- a/crates/wgrapier/src/dynamics/body.rs
+++ b/crates/wgrapier/src/dynamics/body.rs
@@ -132,7 +132,6 @@ pub struct GpuBodySet {
     //       is from wgsparkl which has its own way of storing indices.
     pub(crate) shapes_local_vertex_buffers: GpuVector<Point<f32>>,
     pub(crate) shapes_vertex_buffers: GpuVector<Point<f32>>,
-    pub(crate) shapes_index_buffers: GpuVector<u32>,
     pub(crate) shapes_vertex_collider_id: GpuVector<u32>, // NOTE: this is a bit of a hack for wgsparkl
 }
 
@@ -300,11 +299,6 @@ impl GpuBodySet {
                 device,
                 // TODO: init in world-space directly?
                 &shape_buffers.vertices,
-                BufferUsages::STORAGE,
-            ),
-            shapes_index_buffers: GpuVector::init(
-                device,
-                &shape_buffers.indices,
                 BufferUsages::STORAGE,
             ),
             shapes_vertex_collider_id: GpuVector::init(

--- a/crates/wgrapier/src/pipeline.rs
+++ b/crates/wgrapier/src/pipeline.rs
@@ -20,7 +20,6 @@ use naga_oil::compose::ComposerError;
 use nalgebra::Vector4;
 use rapier::dynamics::{ImpulseJointSet, RigidBodySet};
 use rapier::geometry::ColliderSet;
-use rapier::math::Vector;
 use std::collections::HashMap;
 use std::time::Duration;
 use wgcore::gpu::GpuInstance;
@@ -209,6 +208,8 @@ impl GpuPhysicsState {
         //       them empty. This won’t have any performance impact.
         if shape_buffers.vertices.is_empty() {
             shape_buffers.vertices.push(Point::origin());
+        }
+        if shape_buffers.indices.is_empty() {
             shape_buffers.indices.extend_from_slice(&[0; 3]);
         }
 
@@ -462,7 +463,6 @@ impl GpuPhysicsPipeline {
             state.poses.len() as u32,
             &state.poses,
             &state.vertex_buffers,
-            &state.index_buffers,
             &state.shapes,
             &state.num_shapes,
         );

--- a/crates/wgrapier/src_testbed/graphics.rs
+++ b/crates/wgrapier/src_testbed/graphics.rs
@@ -4,23 +4,28 @@ use rapier2d as rapier;
 use rapier3d as rapier;
 
 use crate::backend::PhysicsBackend;
+use crate::SimulationState;
 use kiss3d::nalgebra::Point3;
+#[cfg(feature = "dim3")]
+use kiss3d::prelude::InstanceData;
+#[cfg(feature = "dim3")]
+use kiss3d::scene::SceneNode;
 use kiss3d::window::Window;
 use rapier::math::DIM;
 use rapier::parry::shape::ShapeType;
 use std::collections::HashMap;
 use std::ops::MulAssign;
-
-use crate::SimulationState;
-#[cfg(feature = "dim3")]
-use kiss3d::prelude::InstanceData;
 #[cfg(feature = "dim2")]
-use kiss3d::prelude::{PlanarInstanceData, PlanarSceneNode};
-use kiss3d::procedural::RenderMesh;
-#[cfg(feature = "dim3")]
-use kiss3d::scene::SceneNode;
-#[cfg(feature = "dim3")]
-use nalgebra::Vector3;
+use {
+    kiss3d::{
+        prelude::{PlanarInstanceData, PlanarSceneNode},
+        resource::PlanarMesh,
+    },
+    nalgebra::{Point2, UnitComplex, Vector2},
+    rapier::parry::bounding_volume::Aabb,
+    std::cell::RefCell,
+    std::rc::Rc,
+};
 
 pub struct InstancedNodeEntry {
     pub index: usize,
@@ -70,9 +75,12 @@ pub async fn setup_graphics(window: &mut Window, phys: &SimulationState) -> Rend
             match shape.shape_type() {
                 ShapeType::Ball => Point3::new(55.0, 126.0, 184.0) * coeff,
                 ShapeType::Cuboid => Point3::new(55.0, 126.0, 34.0) * coeff,
+                #[cfg(feature = "dim3")]
                 ShapeType::Cylinder => Point3::new(140.0, 86.0, 75.0) * coeff,
+                #[cfg(feature = "dim3")]
                 ShapeType::Cone => Point3::new(255.0, 217.0, 47.0) * coeff,
                 ShapeType::Capsule => Point3::new(204.0, 121.0, 167.0) * coeff,
+                #[cfg(feature = "dim3")]
                 ShapeType::ConvexPolyhedron => Point3::new(228.0, 26.0, 28.0) * coeff,
                 _ => Point3::new(255.0, 127.0, 0.0) * coeff,
             }
@@ -89,7 +97,7 @@ pub async fn setup_graphics(window: &mut Window, phys: &SimulationState) -> Rend
                         //       100K+ instances because it uses a lot of subdivision. Create one
                         //       with lower details.
                         let lowres_sphere = kiss3d::procedural::sphere(1.0, 10, 10, true);
-                        window.add_render_mesh(lowres_sphere, Vector3::repeat(1.0))
+                        window.add_render_mesh(lowres_sphere, nalgebra::Vector3::repeat(1.0))
                     };
                     InstancedNode {
                         node,
@@ -123,11 +131,9 @@ pub async fn setup_graphics(window: &mut Window, phys: &SimulationState) -> Rend
                     scale: (cuboid.half_extents * 2.0).into(),
                 })
             }
+            #[cfg(feature = "dim3")]
             ShapeType::Cylinder => {
                 let instanced_node = instances.entry(ShapeType::Cylinder).or_insert_with(|| {
-                    #[cfg(feature = "dim2")]
-                    let node = window.add_rectangle(1.0, 1.0);
-                    #[cfg(feature = "dim3")]
                     let node = window.add_cylinder(1.0, 1.0);
                     InstancedNode {
                         node,
@@ -142,11 +148,9 @@ pub async fn setup_graphics(window: &mut Window, phys: &SimulationState) -> Rend
                     scale: [cyl.radius, cyl.half_height * 2.0, cyl.radius],
                 })
             }
+            #[cfg(feature = "dim3")]
             ShapeType::Cone => {
                 let instanced_node = instances.entry(ShapeType::Cone).or_insert_with(|| {
-                    #[cfg(feature = "dim2")]
-                    let node = window.add_rectangle(1.0, 1.0);
-                    #[cfg(feature = "dim3")]
                     let node = window.add_cone(1.0, 1.0);
                     InstancedNode {
                         node,
@@ -177,10 +181,34 @@ pub async fn setup_graphics(window: &mut Window, phys: &SimulationState) -> Rend
                 instanced_node.entries.push(InstancedNodeEntry {
                     index: i,
                     color: [color.x, color.y, color.z, 1.0],
+                    #[cfg(feature = "dim2")]
+                    scale: [c.radius * 2.0, c.segment.length()],
+                    #[cfg(feature = "dim3")]
                     scale: [c.radius * 2.0, c.segment.length(), c.radius * 2.0],
                 })
             }
+            #[cfg(feature = "dim2")]
+            ShapeType::ConvexPolygon => {
+                let poly = shape.as_convex_polygon().unwrap();
+                let node = window
+                    .add_convex_polygon(poly.points().to_vec(), nalgebra::Vector2::repeat(1.0));
+
+                let mut singleton = InstancedNode {
+                    node,
+                    entries: vec![],
+                    data: vec![],
+                };
+                singleton.entries.push(InstancedNodeEntry {
+                    index: i,
+                    color: [color.x, color.y, color.z, 1.0],
+                    scale: [1.0, 1.0],
+                });
+                singletons.push(singleton);
+            }
+            #[cfg(feature = "dim3")]
             ShapeType::ConvexPolyhedron => {
+                use kiss3d::procedural::RenderMesh;
+
                 let poly = shape.as_convex_polyhedron().unwrap();
                 let (vtx, idx) = poly.to_trimesh();
                 let trimesh = rapier::parry::shape::TriMesh::new(vtx, idx).unwrap();
@@ -188,7 +216,7 @@ pub async fn setup_graphics(window: &mut Window, phys: &SimulationState) -> Rend
                 // Use face normals as vertex normals for flat shading.
                 render.replicate_vertices();
                 render.recompute_normals();
-                let node = window.add_render_mesh(render, Vector3::repeat(1.0));
+                let node = window.add_render_mesh(render, nalgebra::Vector3::repeat(1.0));
                 let mut singleton = InstancedNode {
                     node,
                     entries: vec![],
@@ -201,13 +229,16 @@ pub async fn setup_graphics(window: &mut Window, phys: &SimulationState) -> Rend
                 });
                 singletons.push(singleton);
             }
+            #[cfg(feature = "dim3")]
             ShapeType::TriMesh => {
+                use kiss3d::procedural::RenderMesh;
+
                 let trimesh = shape.as_trimesh().unwrap();
                 let mut render = RenderMesh::from(trimesh.clone());
                 // Use face normals as vertex normals for flat shading.
                 render.replicate_vertices();
                 render.recompute_normals();
-                let node = window.add_render_mesh(render, Vector3::repeat(1.0));
+                let node = window.add_render_mesh(render, nalgebra::Vector3::repeat(1.0));
                 let mut singleton = InstancedNode {
                     node,
                     entries: vec![],
@@ -216,7 +247,50 @@ pub async fn setup_graphics(window: &mut Window, phys: &SimulationState) -> Rend
                 singleton.entries.push(InstancedNodeEntry {
                     index: i,
                     color: [color.x, color.y, color.z, 1.0],
-                    scale: [1.0, 1.0, 1.0],
+                    scale: [1.0; DIM],
+                });
+                singletons.push(singleton);
+            }
+            #[cfg(feature = "dim2")]
+            ShapeType::Polyline => {
+                let polyline = shape.as_polyline().unwrap();
+                let mut vtx = vec![];
+                let mut idx = vec![];
+                for segment in polyline.segments() {
+                    let thickness = 0.2;
+                    let center = nalgebra::center(&segment.a, &segment.b);
+                    let length = nalgebra::distance(&segment.a, &segment.b);
+                    let rot =
+                        UnitComplex::rotation_between(&Vector2::y(), &segment.scaled_direction());
+                    let aabb = Aabb::from_half_extents(
+                        Point2::origin(),
+                        Vector2::new(thickness, length / 2.0),
+                    );
+                    let (mut seg_vtx, mut seg_idx) = aabb.to_trimesh();
+                    seg_vtx.iter_mut().for_each(|pt| {
+                        *pt = rot * *pt + center.coords;
+                    });
+                    seg_idx.iter_mut().for_each(|ii| {
+                        ii[0] += vtx.len() as u32;
+                        ii[1] += vtx.len() as u32;
+                        ii[2] += vtx.len() as u32;
+                    });
+                    vtx.extend_from_slice(&seg_vtx);
+                    idx.extend(seg_idx.iter().map(|ii| Point3::from(ii.map(|i| i as u16))));
+                }
+                let node = window.add_planar_mesh(
+                    Rc::new(RefCell::new(PlanarMesh::new(vtx, idx, None, false))),
+                    Vector2::repeat(1.0),
+                );
+                let mut singleton = InstancedNode {
+                    node,
+                    entries: vec![],
+                    data: vec![],
+                };
+                singleton.entries.push(InstancedNodeEntry {
+                    index: i,
+                    color: [color.x, color.y, color.z, 1.0],
+                    scale: [1.0; DIM],
                 });
                 singletons.push(singleton);
             }

--- a/crates/wgrapier/src_testbed/ui.rs
+++ b/crates/wgrapier/src_testbed/ui.rs
@@ -39,6 +39,17 @@ impl PhysicsContext {
     }
 }
 
+pub fn render_compiling_message(window: &mut Window) {
+    window.draw_ui(|ctx| {
+        kiss3d::egui::Window::new("Settings").show(ctx, |ui| {
+            ui.colored_label(
+                kiss3d::egui::Color32::from_rgb(100, 180, 255),
+                "⏳ COMPILING SHADERS...\nThe app will freeze for a few seconds.\n\nIf nothing happens after a minute or two, check the dev console for an error.",
+            );
+        });
+    });
+}
+
 pub fn render_ui(
     window: &mut Window,
     builders: &SimulationBuilders,


### PR DESCRIPTION
This is our last PR of our series of PR to bring wgrapier up to (almost) feature-parity compared to rapier regarding support collision shapes. Other PRs from this series:
- #12
- #13 
- #14 

All the PRs above were focused on 3D only. This PR handles 2D by implementing the 2D version of EPA, the various support functions, and polylines (which are the 2D replacement of 3D triangle meshes).

This also switches to the latest version of Kiss3D to fix a bug where the UI would not show up on displays with a HiDpi factor of 1 exactly.

The 2D testbed has been modified to add a `primitives` and `polyline` demos. In particular, the `polyline` demo shows that collision-detection between polylines and all primitive shapes, and convex polygons, work as expected.

https://github.com/user-attachments/assets/a7439410-d7eb-40d1-ac99-21cb76c1d801

With this PR, the CI is expected to pass now.