### PR TITLE
fix: significantly improve shader loading speed

### DIFF
--- a/crates/wgrapier/src_testbed/lib.rs
+++ b/crates/wgrapier/src_testbed/lib.rs
@@ -128,7 +128,6 @@ impl Testbed {
             &mut self.cached_gpu_pipeline,
         )
         .await;
-        println!("There");
 
         let mut render_ctx = setup_graphics(&mut window, &phys).await;
 


### PR DESCRIPTION
The `naga_oil` preprocessor was just being very slow compared to just extracting the module name manually.
This reduces the shader loading down from a minute to a few seconds.